### PR TITLE
Wrapper script to manage RAM util when translating control dataset shards

### DIFF
--- a/src/control_translation/translatemultiple.py
+++ b/src/control_translation/translatemultiple.py
@@ -2,6 +2,8 @@ import os
 from centralized_translation import rlu, jat, torchrlds, procgen, custom_shard_func
 from argparse import ArgumentParser
 import tensorflow as tf
+import gc
+import psutil
 
 def build_arg_parser() -> ArgumentParser:
 
@@ -35,6 +37,9 @@ def translate_shards(dataset_name, dataset_path, hf_test_data, limit_schema, out
                         tf.data.Dataset.save(translated_ds,os.path.join(output_dir, 'translated_shard_'+str(idx)), shard_func = custom_shard_func)
                         print('Translated and stored')
                 elif dataset_name=='vd4rl' or dataset_name=='locomujoco' or dataset_name=='language_table' or dataset_name=='openx':
+                    if os.path.exists(os.path.join(output_dir, 'translated_shard_'+str(idx))):
+                        print(f'Skipping because shard {idx} is already translated and saved')
+                        continue
                     translated_ds = torchrlds(shard_path, dataset_name, limit_schema)
                     tf.data.Dataset.save(translated_ds,os.path.join(output_dir, 'translated_shard_'+str(idx)), shard_func = custom_shard_func)
                     print('Translated and stored')

--- a/src/control_translation/translatemultiple.py
+++ b/src/control_translation/translatemultiple.py
@@ -37,11 +37,11 @@ def translate_shards(dataset_name, dataset_path, hf_test_data, limit_schema, out
                         tf.data.Dataset.save(translated_ds,os.path.join(output_dir, 'translated_shard_'+str(idx)), shard_func = custom_shard_func)
                         print('Translated and stored')
                 elif dataset_name=='vd4rl' or dataset_name=='locomujoco' or dataset_name=='language_table' or dataset_name=='openx':
-                    if os.path.exists(os.path.join(output_dir, 'translated_shard_'+str(idx))):
+                    if os.path.exists(os.path.join(os.path.join(output_dir, root.split('/')[-1]), 'translated_shard_'+str(idx))):
                         print(f'Skipping because shard {idx} is already translated and saved')
                         continue
                     translated_ds = torchrlds(shard_path, dataset_name, limit_schema)
-                    tf.data.Dataset.save(translated_ds,os.path.join(output_dir, 'translated_shard_'+str(idx)), shard_func = custom_shard_func)
+                    tf.data.Dataset.save(translated_ds,os.path.join(os.path.join(output_dir, root.split('/')[-1])), shard_func = custom_shard_func)
                     print('Translated and stored')
                 elif dataset_name=='procgen':
                     translated_ds = procgen(root, limit_schema) #Enter parent folder of a given procgen dataset

--- a/src/control_translation/wrapper_translate_multiple.py
+++ b/src/control_translation/wrapper_translate_multiple.py
@@ -1,0 +1,55 @@
+#Script to manage RAM utilization when translating and saving control data shards to disk 
+import psutil
+import subprocess
+import time
+import argparse
+import sys
+
+MAX_RAM_USAGE = 80  # Maximum RAM usage percentage
+PYTHON_EXECUTABLE = "python"  # or "python3" depending on your system
+MAIN_SCRIPT = "translatemultiple.py"
+
+def get_ram_usage():
+    return psutil.virtual_memory().percent
+
+def run_main_program(dataset_name, dataset_path, output_dir):
+    cmd = [
+        PYTHON_EXECUTABLE, 
+        MAIN_SCRIPT, 
+        '--dataset_name', dataset_name,
+        '--dataset_path', dataset_path,
+        '--output_dir', output_dir
+    ]
+    process = subprocess.Popen(cmd)
+    while True:
+        ram_usage = get_ram_usage()
+        if ram_usage > MAX_RAM_USAGE:
+            print(f"RAM usage is {ram_usage}%. Restarting...")
+            process.terminate()
+            process.wait()
+            return -1
+        
+        if process.poll() is not None:
+            print("Process completed successfully.")
+            return None  # Indicate that processing is complete
+        
+        time.sleep(10)  # Check RAM usage every 10 seconds
+
+def main():
+    parser = argparse.ArgumentParser(description='Wrapper to avoid RAM bottlenecks when translating control dataset shards.')
+    parser.add_argument("--dataset_name", type=str, required=True, help="Mention the dataset in MultiNet that needs to be translated. Different datasets are: 'dm_lab_rlu', 'dm_control_suite_rlu', 'ale_atari', 'baby_ai', 'mujoco', 'vd4rl', 'meta_world', 'procgen', 'language_table', 'openx', 'locomuojoco' ")
+    parser.add_argument("--dataset_path", type=str, required=True, help="Provide the path to the specified dataset file")
+    parser.add_argument("--output_dir", type=str, required=True, help="Provide the path to store the translated dataset")
+    parser.add_argument("--limit_schema", type=bool, default=False, help="Set to True if schema needs to be trimmed to [observations, actions, rewards]")
+    parser.add_argument("--hf_test_data", type=bool, default=False, help="Set to True if test split from Huggingface JAT datasets needs to be returned along with train data")
+    
+    args = parser.parse_args()
+
+    while True:
+        start_index = run_main_program( args.dataset_name, args.dataset_path, args.output_dir)
+        if start_index is None:
+            break  # All shards processed
+        time.sleep(60)  # Wait for 60 seconds before restarting to allow system cleanup
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/download_eval.py
+++ b/src/eval/download_eval.py
@@ -44,7 +44,7 @@ def dl_eval(dataset_name: str, output_dir: str):
         ds = load_dataset("tau/commonsense_qa", trust_remote_code=True)
     elif dataset_name == 'mmlu':
         ds = load_dataset("cais/mmlu", "all", trust_remote_code=True)
-    
+
 
     os.makedirs(os.path.join(output_dir, dataset_name), exist_ok=True)
     ds.save_to_disk(os.path.join(output_dir, dataset_name))


### PR DESCRIPTION
Translation of control dataset shards to TFDS is a very RAM intensive process, especially due to tf.data.Dataset.save(). This wrapper script checks RAM util when running the translation script and restarts the program everytime the RAM util goes above 80%.