### PR TITLE
VLMModule for OpenX profiling setting

### DIFF
--- a/src/modules/modality_modules/vlm_module.py
+++ b/src/modules/modality_modules/vlm_module.py
@@ -1,21 +1,96 @@
 from src.modules.source_modules.openai_module import OpenAIModule
+from typing import Any, Union
+
 
 class VLMModule:
-    def __init__(self, source):
-        source_module = None
-        if source == 'openai':
-            source_module = OpenAIModule()
+    def __init__(self, source: str, model: str, system_prompt: str) -> None:
+        self.source_module = None
+        if source == 'openai': 
+            self.source_module = OpenAIModule(system_prompt, model)
 
-        assert source_module is not None, "The source module has not been set correcly. Check required."
+        assert self.source_module is not None, "The source module has not been set correcly. Check required."
+    
+    # cur_inputs: (B, N) => Each element is tuple (type, value)
+    # Any image inputs should be tagged with the type starting with 'image...' to be correctly converted into image input.
+    # Any other data will be considered into text data.
+    # k_shots_examples: (B, k, N) => Each element is tuple (input/output, type, value)
+    # Each element should indicate if it is input or output when included as a few-shot example.
+    # Otherwise, the few-shot prompting would not work as intended.
+    def infer_step(self, 
+                   cur_inputs: list[list[tuple[str, Any]]], 
+                   k_shots_examples: list[list[tuple[str, Any]]]=[]
+                ) -> list[str]:
+        if isinstance(self.source_module, OpenAIModule):
+            processed_cur_inputs, processed_k_shots_examples = self._process_inputs_for_api(cur_inputs, k_shots_examples)
+            batch_size = len(processed_cur_inputs)
 
-    # TODO: Processing the input according to the source module.
-    def process_input():
-        pass
+            # The close-sourced API call only support batch size 1.
+            outputs = []
+            for b in range(batch_size):
+                num_examples = 0
+                if len(processed_cur_inputs) == len(processed_k_shots_examples):
+                    num_examples = len(processed_k_shots_examples[b])
+                for k in range(num_examples):
+                    for data in processed_k_shots_examples[b][k]:
+                        if isinstance(data, list):
+                            self.source_module.add_multi_modal_data('input', data)
+                        else:
+                            self.source_module.add_text_data('output', data)
 
-    # TODO: Processing the output according to the source module.
-    def process_output():
-        pass
+                output = self.source_module.infer_step_with_images(processed_cur_inputs[b])
+                outputs.append(output)
 
-    # TODO: One inference step.
-    def infer_step():
-        pass
+                # Clearing the record.
+                self.source_module.clear_history()
+
+            return outputs
+        
+    # Translating the input data into image/text format.
+    def _process_inputs_for_api(self, 
+                   cur_inputs: list[list[tuple[str, Any]]], 
+                   k_shots_examples: list[list[tuple[str, Any]]]=[]
+                ) -> tuple[list[list[dict]], list[list[Union[list[dict], str]]]]:
+        batch_size = len(cur_inputs)
+        processed_cur_inputs, processed_k_shots_examples = [], []
+        for b in range(batch_size):
+            processed_inputs = []
+            for type, value in cur_inputs[b]:
+                if type.startswith('image'):
+                    processed_inputs.append({'image': value})
+                else:
+                    processed_inputs.append({'text': self._convert_into_text(type, value)})
+            processed_cur_inputs.append(processed_inputs)
+
+        # If there are k-shots examples, processing them.
+        if len(k_shots_examples) > 0:
+            assert len(k_shots_examples) == batch_size, "The size of k_shots_examples should be the same as batch size."
+            for b in range(batch_size):
+                num_examples = len(k_shots_examples[b])
+                processed_k_shots_examples.append([])
+
+                for k in range(num_examples):
+                    processed = []
+                    for tup in k_shots_examples[b][k]:
+                        if tup[0] == 'output':
+                            processed.append(tup[1])
+                        elif tup[0] == 'input':
+                            data = []
+                            for type, value in tup[1]:
+                                if type.startswith('image'):
+                                    data.append({'image': value})
+                                else:
+                                    data.append({'text': self._convert_into_text(type, value)})
+                            processed.append(data)
+                        else:
+                            raise NotImplementedError("The k-shot examples should have category either 'input' or 'output'.")
+                    processed_k_shots_examples[b].append(processed)
+
+        return processed_cur_inputs, processed_k_shots_examples
+
+    # Converting the key-value pair in the input into a text form.
+    def _convert_into_text(self, key: str, value: Any) -> str:
+        try:
+            value_str = str(value)
+            return f"{key}: {value_str}"
+        except:
+            raise ValueError(f"The value {value} cannot be converted into text.")

--- a/src/modules/source_modules/openai_module.py
+++ b/src/modules/source_modules/openai_module.py
@@ -1,8 +1,12 @@
 from openai import OpenAI
 from typing import Union
+from PIL import Image
+from io import BytesIO
 
 import tiktoken
 import math
+import numpy as np
+import base64
 
 CONTEXT_SIZE_MAP = {
     'gpt-4o': 128000,
@@ -26,45 +30,56 @@ class OpenAIModule:
         if model not in CONTEXT_SIZE_MAP:
             raise KeyError(f"The model {model} is not currenly supported.")
         
-        self.messages = []
+        self.history = []
         self.model = model
         self.max_num_tokens = CONTEXT_SIZE_MAP[model]
         self.cur_num_tokens_cache = []
-        self.system_message = {'role': 'system', 'content': system_prompt}
 
+        self.system_message = {'role': 'system', 'content': system_prompt}
         self.client = OpenAI()
         try:
             self.encoding = tiktoken.encoding_for_model(self.model)
         except KeyError:
             self.encoding = tiktoken.get_encoding('cl100k_base')
 
-    # One chat completion only with text messages.
-    def chat_completion_basic(self, text_query: str) -> str:
-        self.add_message({'role': 'user', 'content': text_query})
+    # One inference step.
+    def infer_step(self, text: str=None, images: np.array=None) -> str:
+        assert text is not None or images is not None, "Either text or images should not be None."
+        self.add_data_into_history('input', text, images)
         response = self.get_response_from_api()
-        self.add_message({'role': 'assistant', 'content': response})
+        self.add_data_into_history('output', response)
         return response
+    
+    # Adding new data in the context history.
+    def add_data_into_history(self, type: str, text: str=None, images: np.array=None) -> None:  # images: (F, W, H, C) or (F, W, H)
+        assert type == 'input' or type == 'output', "The data type should be either 'input' or 'output'."
+        assert text is not None or images is not None, "Either text or images should not be None."
 
-    # One chat completion with text + images.
-    def chat_completion_multi_modal(self, image_urls: list[str], image_sizes: list[tuple[int, int]], text_query: str=None) -> str:
-        content = []
-        for image_url in image_urls:
-            content.append({
-                'type': 'image_url',
-                'image_url': {
-                    'url': image_url
-                }
-            })
-        if text_query is not None: content.append({'type': 'text', 'text': text_query})
-        self.add_message({'role': 'user', 'content': content}, image_sizes)
-        response = self.get_response_from_api()
-        self.add_message({'role': 'assistant', 'content': response})
-        return response
+        role = 'user' if type == 'input' else 'assistant'
+        if images is None:
+            message = {'role': role, 'content': text}
+            self.history.append(message)
+            self.cur_num_tokens_cache.append(self.get_text_message_num_tokens(message['role'], message['content']))
+        else:
+            image_urls, image_size = self.process_images_for_api(images)
+            message = {'role': role, 'content': []}
+            for image_url in image_urls:
+                message['content'].append({'type': 'image_url', 'image_url': {'url': image_url}})
+            if text is not None: message['content'].append({'type': 'text', 'text': text})
+            self.history.append(message)
+            self.cur_num_tokens_cache.append(self.get_multi_modal_message_num_tokens(message['role'], [image_size] * images.shape[0], text))
+
+        assert len(self.history) == len(self.cur_num_tokens_cache), "The chat history and num tokens cache should be synced."
+
+    # Clearing the history.
+    def clear_history(self):
+        self.history = []
+        self.cur_num_tokens_cache = []
 
     # Calling the chat completion API.
     def get_response_from_api(self) -> str:
         start_idx = self.find_starting_point()
-        messages = [self.system_message] + self.messages[start_idx:]
+        messages = [self.system_message] + self.history[start_idx:]
         response = self.client.chat.completions.create(
             model=self.model,
             messages=messages,
@@ -72,40 +87,21 @@ class OpenAIModule:
         )
 
         return response.choices[0].message.content
-    
-    # Adding a message into the chat history.
-    def add_message(self, message: dict[str, Union[str, list[dict]]], image_sizes: list[tuple[int, int]]=None):
-        num_tokens = self.get_message_num_tokens(message, image_sizes)
-        self.messages.append(message)
-        self.cur_num_tokens_cache.append(num_tokens)
-        assert len(self.messages) == len(self.cur_num_tokens_cache), "The chat history and num tokens cache should be synced."
-    
+
     # Calculating the number of tokens in one message only with text.
-    def get_text_message_num_tokens(self, message: dict[str, str]) -> int:
+    def get_text_message_num_tokens(self, role: str, content: str) -> int:
         num_tokens = 3  # <|start|>, \n, <|end|>
-        num_tokens += len(self.encoding.encode(message['role']))
-        num_tokens += len(self.encoding.encode(message['content']))
+        num_tokens += len(self.encoding.encode(role))
+        num_tokens += len(self.encoding.encode(content))
         return num_tokens
     
     # Calculating the number of tokens in one message.
-    def get_message_num_tokens(self, message: dict[str, Union[str, list[dict]]], image_sizes: list[tuple[int, int]]=None) -> int:
-        if image_sizes is None:
-            return self.get_text_message_num_tokens(message)
-        
-        image_contents, text_content = None, None
-        if message['content'][-1]['type'] == 'text':
-            image_contents = message['content'][:-1]
-            text_content = message['content'][-1]
-        else:
-            image_contents = message['content']
-        
-        assert len(image_contents) == len(image_sizes), "The image sizes list should be the same length as the image input list."
-
+    def get_multi_modal_message_num_tokens(self, role: str, image_sizes: list[tuple[int, int]], text: str=None) -> int:
         num_tokens = 3
-        num_tokens += len(self.encoding.encode(message['role']))
-        for i, image_content in enumerate(image_contents):
-            num_tokens += self.get_num_image_tokens(image_sizes[i][0], image_sizes[i][1], detail='high')
-        if text_content is not None: num_tokens += len(self.encoding.encode(text_content['text']))
+        num_tokens += len(self.encoding.encode(role))
+        for image_size in image_sizes:
+            num_tokens += self.get_num_image_tokens(image_size[0], image_size[1], detail='high')
+        if text is not None: num_tokens += len(self.encoding.encode(text))
             
         return num_tokens
 
@@ -139,9 +135,36 @@ class OpenAIModule:
         num_tiles_height = math.ceil(height / 512)
         return 85 + 170 * (num_tiles_width * num_tiles_height)
     
+    # Processing the batched input according to the source module.
+    def process_images_for_api(self, images: np.array) -> tuple[list, tuple]:  # images: (F, W, H, C)
+        image_size = (images.shape[1], images.shape[2])
+        image_urls = []
+        for image in images:
+            image_url = self.convert_image_into_url(image)
+            image_urls.append(image_url)
+        return image_urls, image_size
+
+    # Converting the image array into URLs for API calls.
+    def convert_image_into_url(self, image: np.array) -> str:
+        # Checking the data spec.
+        multiplier, mode = 1.0, 'RGB'
+        if len(image.shape) == 2:  # Grey-scaled image.
+            mode = 'L'
+        if len(image.shape) == 3 and image.shape[-1] == 1:  # Grey-scaled image with extra dimension.
+            mode = 'L'
+            image = np.squeeze(image, axis=-1)
+        if np.max(image) <= 1.0:  # Setting the values in range of 0 ~ 255.
+            multiplier = 255
+        image_converted = Image.fromarray((image * multiplier).astype(np.uint8), mode)
+        
+        buffer = BytesIO()
+        image_converted.save(buffer, format='png')
+
+        return f"data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}"
+    
     # Finding the starting index of the chat history for adjusting the input size.
     def find_starting_point(self, max_response_tokens: int=128) -> int:
-        num_tokens = self.get_message_num_tokens(self.system_message)
+        num_tokens = self.get_text_message_num_tokens(self.system_message)
         assert num_tokens < self.max_num_tokens, "The number of tokens in the system message must be smaller than the context size."
         
         start_idx = len(self.cur_num_tokens_cache)

--- a/tst/modules/modality_modules/vlm_module_test.py
+++ b/tst/modules/modality_modules/vlm_module_test.py
@@ -1,0 +1,450 @@
+import os
+import sys
+ROOT_DIR = os.getcwd()
+sys.path.append(ROOT_DIR)
+os.environ["OPENAI_API_KEY"] = "random-api-key"
+
+from src.modules.modality_modules.vlm_module import VLMModule
+from src.modules.source_modules.openai_module import OpenAIModule
+from unittest.mock import MagicMock, call
+
+import unittest
+import numpy as np
+
+
+class VLMModuleTest(unittest.TestCase):
+    def test_constructor(self):
+        # Testing OpenAIModule.
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a test system prompt."
+        module = VLMModule(source, model, system_prompt)
+        self.assertTrue(isinstance(module.source_module, OpenAIModule))
+
+        # TODO: Add any source module constructor test. newly implemented.
+        
+        # Testing constructor failure.
+        source = 'dummy'
+        model = 'dummy-model'
+        with self.assertRaises(AssertionError):
+            module = VLMModule(source, model, system_prompt)
+
+    def test_convert_into_text(self):
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a test system prompt."
+        module = VLMModule(source, model, system_prompt)
+
+        self.assertEqual(module._convert_into_text('key1', "This is a value."), "key1: This is a value.")
+        self.assertEqual(module._convert_into_text('key2', [1, 2, 3, 'v1', 'v2']), "key2: [1, 2, 3, 'v1', 'v2']")
+        self.assertEqual(module._convert_into_text('key3', {'k1': 'v1', 'k2': 16, 'k3': [10, 20, '30']}), "key3: {'k1': 'v1', 'k2': 16, 'k3': [10, 20, '30']}")
+        self.assertEqual(module._convert_into_text('key4', np.array([[1,2,3,4],[5,6,7,8],[9,10,11,12]])), "key4: [[ 1  2  3  4]\n [ 5  6  7  8]\n [ 9 10 11 12]]")
+        self.assertEqual(module._convert_into_text('key5', 100.2478), "key5: 100.2478")
+
+    def test_process_inputs_for_api_zero_shot(self):
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a text system prompt."
+        module = VLMModule(source, model, system_prompt)
+
+        cur_inputs = [
+            [
+                ('image_observation', np.random.randint(256, size=(100, 40, 3))),
+                ('image_observation', np.random.randint(256, size=(100, 40, 3))),
+                ('text_observation', "This is text instruction 1.")
+            ],
+            [
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('text_observation', "This is text instruction 2."),
+                ('discrete_observation', np.random.randint(2, size=(12)))
+            ],
+            [
+                ('image_observation', np.random.randint(256, size=(64, 64, 3)))
+            ],
+            [
+                ('reward', "100.45865"),
+                ('image_observation', np.random.randint(256, size=(1024, 1024, 3))),
+                ('image_observation', np.random.randint(256, size=(1024, 1024, 3))),
+                ('continuous_observation', np.random.random_sample(size=(8)))
+            ]
+        ]
+        processed_cur_inputs, processed_k_shots_examples = module._process_inputs_for_api(cur_inputs)
+
+        self.assertEqual(processed_k_shots_examples, [])
+        self.assertEqual(len(processed_cur_inputs), len(cur_inputs))
+
+        for b in range(len(cur_inputs)):
+            self.assertEqual(len(processed_cur_inputs[b]), len(cur_inputs[b]))
+            for i in range(len(cur_inputs[b])):
+                if cur_inputs[b][i][0].startswith('image_'):
+                    self.assertEqual(processed_cur_inputs[b][i], {'image': cur_inputs[b][i][1]})
+                else:
+                    self.assertEqual(processed_cur_inputs[b][i], {'text': f"{cur_inputs[b][i][0]}: {cur_inputs[b][i][1]}"})
+
+    def test_process_inputs_for_api_one_shot(self):
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a test system prompt."
+        module = VLMModule(source, model, system_prompt)
+
+        cur_inputs = [
+            [
+                ('image_observation', np.random.randint(256, size=(256, 256, 4))),
+                ('image_observation', np.random.randint(256, size=(100, 40, 4))),
+                ('text_observation', "Hi, how are you?"),
+                ('text_observation', "This is an instruction.")
+            ],
+            [
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('image_observation', np.random.randint(256, size=(128, 128, 3))),
+                ('continuous_observation', np.random.random_sample(size=(32))),
+                ('discrete_observation', np.random.randint(2, size=(12)))
+            ],
+            [
+                ('discrete_observation', np.random.randint(4, size=(8))),
+                ('image_observation', np.random.randint(256, size=(120, 80, 4)))
+            ]
+        ]
+        k_shots_examples = [
+            [
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(64, 64, 4))),
+                        ('text_observation', "This is the first demonstration."),
+                        ('text_observation', "Check carefully how it is solved.")
+                    ]),
+                    ('output', "This is example output 1.")
+                ]
+            ],
+            [
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(512, 512, 3))),
+                        ('image_observation', np.random.randint(256, size=(512, 512, 3))),
+                        ('image_observation', np.random.randint(256, size=(512, 512, 3))),
+                        ('continuous_observation', np.random.random_sample(size=(32))),
+                        ('discrete_observation', np.random.randint(2, size=(12)))
+                    ]),
+                    ('output', "This is example output 2.")
+                ]
+            ],
+            [
+                [
+                    ('input', [
+                        ('discrete_observation', np.random.randint(4, size=(8))),
+                        ('image_observation', np.random.randint(256, size=(120, 80, 4)))
+                    ]),
+                    ('output', str(np.random.randint(8, size=(6)))),
+                    ('input', [
+                        ('reward', "24.102")
+                    ])
+                ]
+            ]
+        ]
+        processed_cur_inputs, processed_k_shots_examples = module._process_inputs_for_api(cur_inputs, k_shots_examples)
+
+        self.assertEqual(len(processed_cur_inputs), len(cur_inputs))
+        self.assertEqual(len(processed_k_shots_examples), len(k_shots_examples))
+
+        for b in range(len(cur_inputs)):
+            self.assertEqual(len(processed_cur_inputs[b]), len(cur_inputs[b]))
+            for i in range(len(cur_inputs[b])):
+                if cur_inputs[b][i][0].startswith('image_'):
+                    self.assertEqual(processed_cur_inputs[b][i], {'image': cur_inputs[b][i][1]})
+                else:
+                    self.assertEqual(processed_cur_inputs[b][i], {'text': f"{cur_inputs[b][i][0]}: {cur_inputs[b][i][1]}"})
+
+        for b in range(len(k_shots_examples)):
+            self.assertEqual(len(processed_k_shots_examples[b]), len(k_shots_examples[b]))
+            num_examples = len(k_shots_examples[b])
+            for k in range(num_examples):
+                self.assertEqual(len(processed_k_shots_examples[b][k]), len(k_shots_examples[b][k]))
+                for i in range(len(k_shots_examples[b][k])):
+                    if k_shots_examples[b][k][i][0] == 'output':
+                        self.assertEqual(processed_k_shots_examples[b][k][i], k_shots_examples[b][k][i][1])
+                    else:
+                        expected_data = []
+                        for type, value in k_shots_examples[b][k][i][1]:
+                            if type.startswith('image_'):
+                                expected_data.append({'image': value})
+                            else:
+                                expected_data.append({'text': f"{type}: {value}"})
+                        self.assertEqual(processed_k_shots_examples[b][k][i], expected_data)
+
+    def test_process_inputs_for_api_three_shots(self):
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a test system prompt."
+        module = VLMModule(source, model, system_prompt)
+
+        cur_inputs = [
+            [
+                ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                ('text_observation', "Describe the pictures."),
+            ],
+            [
+                ('image_observation', np.random.randint(256, size=(1024, 1024, 3))),
+                ('image_observation', np.random.randint(256, size=(512, 764, 4))),
+                ('continuous_observation', np.random.random_sample(size=(20))),
+                ('discrete_observation', np.random.randint(4, size=(16)))
+            ],
+            [
+                ('discrete_observation', np.random.randint(2, size=(100))),
+                ('image_observation', np.random.randint(256, size=(24, 24, 4))),
+                ('image_observation', np.random.randint(256, size=(24, 24, 4)))
+            ],
+            [
+                ('image_observation', np.random.randint(256, size=(48, 96, 3))),
+                ('text_observation', "Solve this puzzle."),
+                ('continuous_observation', np.random.random_sample(size=(10)))
+            ]
+        ]
+        k_shots_examples = [
+            [
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('text_observation', "Describe the pictures (example 1)."),
+                    ]),
+                    ('output', "This is example output 1.")
+                ],
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('text_observation', "Describe the pictures (example 2)."),
+                    ]),
+                    ('output', "This is example output 2.")
+                ],
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('image_observation', np.random.randint(256, size=(160, 160, 4))),
+                        ('text_observation', "Describe the pictures (example 3)."),
+                    ]),
+                    ('output', "This is example output 3.")
+                ],
+            ],
+            [
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(1024, 1024, 3))),
+                        ('image_observation', np.random.randint(256, size=(512, 764, 4))),
+                        ('continuous_observation', np.random.random_sample(size=(20))),
+                        ('discrete_observation', np.random.randint(4, size=(16)))
+                    ]),
+                    ('output', "The correct action is 1."),
+                    ('input', [
+                        ('reward', "120.64")
+                    ])
+                ],
+                [
+                    ('input', [
+                        ('image_observation', np.random.randint(256, size=(1024, 1024, 3))),
+                        ('image_observation', np.random.randint(256, size=(512, 764, 4))),
+                        ('continuous_observation', np.random.random_sample(size=(20))),
+                        ('discrete_observation', np.random.randint(4, size=(16)))
+                    ]),
+                    ('output', "The correct action is 1."),
+                    ('input', [
+                        ('reward', "-10.99")
+                    ])
+                ],
+            ],
+            [
+                [
+                    ('input', [
+                        ('discrete_observation', np.random.randint(2, size=(100))),
+                        ('image_observation', np.random.randint(256, size=(24, 24, 4))),
+                        ('image_observation', np.random.randint(256, size=(24, 24, 4)))
+                    ]),
+                    ('output', str(np.random.randint(4, size=(3)))),
+                    ('input', [
+                        ('reward', "8.3156467")
+                    ])
+                ],
+            ],
+            [
+                []
+            ]
+        ]
+        processed_cur_inputs, processed_k_shots_examples = module._process_inputs_for_api(cur_inputs, k_shots_examples)
+
+        self.assertEqual(len(processed_cur_inputs), len(cur_inputs))
+        self.assertEqual(len(processed_k_shots_examples), len(k_shots_examples))
+
+        for b in range(len(cur_inputs)):
+            self.assertEqual(len(processed_cur_inputs[b]), len(cur_inputs[b]))
+            for i in range(len(cur_inputs[b])):
+                if cur_inputs[b][i][0].startswith('image_'):
+                    self.assertEqual(processed_cur_inputs[b][i], {'image': cur_inputs[b][i][1]})
+                else:
+                    self.assertEqual(processed_cur_inputs[b][i], {'text': f"{cur_inputs[b][i][0]}: {cur_inputs[b][i][1]}"})
+
+        for b in range(len(k_shots_examples)):
+            self.assertEqual(len(processed_k_shots_examples[b]), len(k_shots_examples[b]))
+            num_examples = len(k_shots_examples[b])
+            for k in range(num_examples):
+                self.assertEqual(len(processed_k_shots_examples[b][k]), len(k_shots_examples[b][k]))
+                for i in range(len(k_shots_examples[b][k])):
+                    if k_shots_examples[b][k][i][0] == 'output':
+                        self.assertEqual(processed_k_shots_examples[b][k][i], k_shots_examples[b][k][i][1])
+                    else:
+                        expected_data = []
+                        for type, value in k_shots_examples[b][k][i][1]:
+                            if type.startswith('image_'):
+                                expected_data.append({'image': value})
+                            else:
+                                expected_data.append({'text': f"{type}: {value}"})
+                        self.assertEqual(processed_k_shots_examples[b][k][i], expected_data)
+
+    def test_infer_step_with_openai(self):
+        source = 'openai'
+        model = 'gpt-4o-2024-05-13'
+        system_prompt = "This is a test system prompt."
+        module = VLMModule(source, model, system_prompt)
+
+        # Zero-shot test.
+        processed_cur_inputs = [
+            [
+                {'image': np.random.randint(256, size=(128, 128, 3))},
+                {'image': np.random.randint(256, size=(128, 128, 3))},
+                {'text': "text_observation: This is a text description."},
+                {'text': f"continuous_observation: {np.random.random_sample(size=(12))}"}
+            ],
+            [
+                {'image': np.random.randint(256, size=(50, 100, 3))},
+                {'text': f"discrete_observation: {np.random.randint(8, size=(10))}"}
+            ]
+        ]
+        module._process_inputs_for_api = MagicMock(return_value=(processed_cur_inputs, []))
+        def side_effect(input_data):
+            if input_data == processed_cur_inputs[0]:
+                return "Correctly got the first data for zero-shot."
+            elif input_data == processed_cur_inputs[1]:
+                return "Correctly got the second data for zero-shot."
+            return None
+        module.source_module.infer_step_with_images = MagicMock(side_effect=side_effect)
+        outputs = module.infer_step([], [])
+        self.assertEqual(len(outputs), 2)
+        self.assertEqual(outputs[0], "Correctly got the first data for zero-shot.")
+        self.assertEqual(outputs[1], "Correctly got the second data for zero-shot.")
+
+        # Few-shot test.
+        processed_cur_inputs = [
+            [
+                {'image': np.random.randint(256, size=(256, 256, 3))},
+                {'image': np.random.randint(256, size=(20, 20, 4))},
+                {'text': f"discrete_observation: {np.random.randint(12, size=(24))}"}
+            ],
+            [
+                {'image': np.random.randint(256, size=(240, 240, 4))},
+                {'text': f"text_observation: This is additional text description."},
+                {'image': np.random.randint(256, size=(64, 128, 3))},
+                {'text': f"continuous_observation: {np.random.random_sample(size=(100))}"}
+            ],
+            [
+                {'image': np.random.randint(256, size=(100, 100, 4))},
+            ]
+        ]
+        processed_k_shots_examples = [
+            [
+                [
+                    [
+                        {'image': np.random.randint(256, size=(256, 256, 3))},
+                        {'image': np.random.randint(256, size=(20, 20, 4))},
+                        {'text': f"discrete_observation: {np.random.randint(12, size=(24))}"}
+                    ],
+                    "The sample output 1 for batch 0."
+                ],
+                [
+                    [
+                        {'image': np.random.randint(256, size=(256, 256, 3))},
+                        {'image': np.random.randint(256, size=(20, 20, 4))},
+                        {'text': f"discrete_observation: {np.random.randint(12, size=(24))}"}
+                    ],
+                    "The sample output 2 for batch 0."
+                ]
+            ],
+            [
+                [
+                    [
+                        {'image': np.random.randint(256, size=(240, 240, 4))},
+                        {'text': f"text_observation: This is additional text description."},
+                        {'image': np.random.randint(256, size=(64, 128, 3))},
+                        {'text': f"continuous_observation: {np.random.random_sample(size=(100))}"}
+                    ],
+                    "The sample output 1 for batch 1.",
+                    [
+                        {'text': "reward: 100.00"}
+                    ]
+                ],
+                [
+                    [
+                        {'image': np.random.randint(256, size=(240, 240, 4))},
+                        {'text': f"text_observation: This is additional text description."},
+                        {'image': np.random.randint(256, size=(64, 128, 3))},
+                        {'text': f"continuous_observation: {np.random.random_sample(size=(100))}"}
+                    ],
+                    "The sample output 2 for batch 1.",
+                    [
+                        {'text': "reward: 18.902"}
+                    ]
+                ]
+            ],
+            [
+                [
+                    [
+                        {'image': np.random.randint(256, size=(100, 100, 4))},
+                    ],
+                    "The sample output 3 for batch 2."
+                ]
+            ]
+        ]
+        module._process_inputs_for_api = MagicMock(return_value=(processed_cur_inputs, processed_k_shots_examples))
+        def side_effect(input_data):
+            if input_data == processed_cur_inputs[0]:
+                return "Correctly got the first data for 2-shots."
+            elif input_data == processed_cur_inputs[1]:
+                return "Correctly got the second data for 2-shots."
+            elif input_data == processed_cur_inputs[2]:
+                return "Correctly got the third data for 2-shots."
+            return None
+        module.source_module.infer_step_with_images = MagicMock(side_effect=side_effect)
+        module.source_module.add_multi_modal_data = MagicMock()
+        module.source_module.add_text_data = MagicMock()
+
+        outputs = module.infer_step([], [])
+        self.assertEqual(len(outputs), 3)
+        self.assertEqual(outputs[0], "Correctly got the first data for 2-shots.")
+        self.assertEqual(outputs[1], "Correctly got the second data for 2-shots.")
+        self.assertEqual(outputs[2], "Correctly got the third data for 2-shots.")
+        module.source_module.add_multi_modal_data.assert_has_calls([
+            call('input', processed_k_shots_examples[0][0][0]),
+            call('input', processed_k_shots_examples[0][1][0]),
+            call('input', processed_k_shots_examples[1][0][0]),
+            call('input', processed_k_shots_examples[1][0][2]),
+            call('input', processed_k_shots_examples[1][1][0]),
+            call('input', processed_k_shots_examples[1][1][2]),
+            call('input', processed_k_shots_examples[2][0][0])
+        ])
+        module.source_module.add_text_data([
+            call('output', processed_k_shots_examples[0][0][1]),
+            call('output', processed_k_shots_examples[0][1][1]),
+            call('output', processed_k_shots_examples[1][0][1]),
+            call('output', processed_k_shots_examples[1][1][1]),
+            call('output', processed_k_shots_examples[2][0][1])
+        ])
+
+
+if __name__=="__main__":
+    unittest.main()


### PR DESCRIPTION
- Most of the OpenAI-specific functions have been moved into OpenAIModule.
    - Converting an image into base64.
    - Getting image sizes.
- OpenAIModule can take any order of vision-language inputs to prepare for the wide range of input types in OpenX.
    - Now, multiple text inputs can be taken, so that they can be used for different modalities such as discreate observations, text observations, or rewards.
- VLMModule has been implemented.
    - It converted any data with the type starting with "image...." into image data. The rest of the inputs are considered as text inputs and converted into text "{type}: {value}". (e.g. `"discrete_observation: [1, 0, 2, 1, 0, 2]"`)
    - It also gets the k-shots examples so that it properly updates the history with the examples. The k-shots examples have extra fields to indicate whether they are user inputs or outputs to map them into the model history as intended.
- Unit tests for VLMModule have been added.