### PR TITLE
Fixes to episode construction in the dataloader and addition of action success rate as a metric

### DIFF
--- a/src/eval/profiling/jat/scripts/jat_openx_eval.py
+++ b/src/eval/profiling/jat/scripts/jat_openx_eval.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 from transformers import AutoModelForCausalLM, AutoProcessor
 from openx_dataloader import get_openx_dataloader
+import wandb
 
 def evaluate_jat_model(model, processor, tfds_shards):
 
@@ -11,11 +12,12 @@ def evaluate_jat_model(model, processor, tfds_shards):
     avg_mse_list = []
     total_dataset_amse = 0.0
     episode_count = 0
+    action_success = []
 
     for batch in dataloader:
 
         episode_mse = []
-	model.reset_rl() # clear key-value cache for each episode
+        model.reset_rl()  # clear key-value cache for each episode
 
         #Because the batch size is 1, 1 batch contains 1 episode, which is why the first element is indexed
         for idx in range(len(batch['continuous_observation'][0])):
@@ -45,6 +47,16 @@ def evaluate_jat_model(model, processor, tfds_shards):
             mse = np.mean((np.array(predicted_action) - np.array(actual_action)) ** 2)
             episode_mse.append(mse)
 
+            # At the last timestep, check if the predicted action is the same as the actual action. If yes, it is considered a success
+            if batch['is_last'][0][idx] == True:
+                print(np.array(predicted_action))
+                print(np.array(actual_action))
+                if np.array_equal(np.array(predicted_action), np.array(actual_action)):
+                    action_success.append(1)
+                else:
+                    action_success.append(0)
+
+
         # Calculate average RMSE for the episode
         avg_episode_mse = np.mean(episode_mse)
         avg_mse_list.append(avg_episode_mse)
@@ -52,6 +64,12 @@ def evaluate_jat_model(model, processor, tfds_shards):
         episode_count += 1
 
         print(f"Episode {episode_count} - Average MSE: {avg_episode_mse:.4f}")
+
+        
+
+    #Action success rate
+    action_success_rate = (sum(action_success) / len(action_success)) * 100
+    print(f"Action Success Rate Percentage for the dataset: {action_success_rate:.4f}")
 
     # Calculate overall average RMSE across all episodes
     print(f"\nTotal Average MSE across {episode_count} episodes: {total_dataset_amse:.4f}")
@@ -67,5 +85,5 @@ def evaluate_jat_model(model, processor, tfds_shards):
 
     print(f"Normalized Average AMSE for dataset: {normalized_amse:.4f}")
 
-    return avg_mse_list, episode_count, total_dataset_amse, normalized_amse
+    return action_success_rate, avg_mse_list, episode_count, total_dataset_amse, normalized_amse
 

--- a/src/eval/profiling/jat/scripts/jat_openx_eval.py
+++ b/src/eval/profiling/jat/scripts/jat_openx_eval.py
@@ -2,7 +2,6 @@ import os
 import numpy as np
 from transformers import AutoModelForCausalLM, AutoProcessor
 from openx_dataloader import get_openx_dataloader
-import wandb
 
 def evaluate_jat_model(model, processor, tfds_shards):
 

--- a/src/eval/profiling/jat/scripts/openx_dataloader.py
+++ b/src/eval/profiling/jat/scripts/openx_dataloader.py
@@ -19,18 +19,18 @@ class OpenXDataset(Dataset):
         current_episode = []
 
         for shard_idx, shard in enumerate(self.tfds_shards):
-            #print(shard)
-            dataset = tf.data.Dataset.load(shard)
 
             # To prevent input processing overhead for shards that have already been processed
             if shard_idx < self.current_shard_idx:
                 continue
+            #print(shard)
+            dataset = tf.data.Dataset.load(shard)
 
             #Process the input data for each element in the shard
             for elem_idx, elem in enumerate(dataset):
 
                 # To prevent input processing overhead for elements of shardsthat have already been processed
-                if shard_idx == self.current_shard_idx and (self.current_elem_idx!=0 and elem_idx < self.current_elem_idx):
+                if shard_idx == self.current_shard_idx and elem_idx < self.current_elem_idx:
                     continue
                     
 
@@ -177,7 +177,7 @@ class OpenXDataset(Dataset):
                     #episodes.append(current_episode)
                     #print(len(current_episode))
                     #print(current_episode[-1])
-                    if shard_idx!=self.current_shard_idx:
+                    if elem_idx+1 == len(dataset):
                         self.current_elem_idx = 0
                     else:
                         self.current_elem_idx = elem_idx+1
@@ -188,12 +188,10 @@ class OpenXDataset(Dataset):
         if current_episode:  # Add the last episode if it's not empty
             #print(len(current_episode))
             #print(current_episode[-1])
-            if shard_idx!=self.current_shard_idx:
-                self.current_elem_idx = 0
-            else:
-                self.current_elem_idx = elem_idx+1
-            self.current_shard_idx = shard_idx
+            self.current_shard_idx = 0
+            self.current_elem_idx = 0
             yield current_episode
+            current_episode = []
             #episodes.append(current_episode)
 
         #return episodes

--- a/src/eval/profiling/jat/scripts/profile_openx.py
+++ b/src/eval/profiling/jat/scripts/profile_openx.py
@@ -4,7 +4,12 @@ import json
 from transformers import AutoModelForCausalLM, AutoProcessor
 from jat_openx_eval import evaluate_jat_model
 import numpy as np
+import wandb
+
 def profile_jat_on_openx():
+
+    wandb.login()
+    run = wandb.init(project="jat-openx-eval", id="cc39qjbx", resume="must")
     # Load the model and processor
     model_name_or_path = "jat-project/jat"
     processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True)
@@ -19,6 +24,15 @@ def profile_jat_on_openx():
     eval_results = {}
 
     for openx_dataset in openx_dataset_paths:
+        # Read the stored JSON file to check completed datasets
+        if os.path.exists('jat_openx_evaluation_results.json'):
+            with open('jat_openx_evaluation_results.json', 'r') as f:
+                completed_datasets = json.load(f)
+            
+            if openx_dataset in completed_datasets:
+                print(f'\nSkipping dataset: {openx_dataset} (already evaluated)\n')
+                continue
+        
         print(f'\nEvaluating dataset: {openx_dataset}\n')
 
         # Get all shards for the current dataset
@@ -31,7 +45,7 @@ def profile_jat_on_openx():
         start_time = time.time()
 
         # Evaluate JAT model on the current dataset
-        avg_mse_list, episode_count, total_dataset_amse, normalized_amse = evaluate_jat_model(model, processor, tfds_shards)
+        action_success_rate, avg_mse_list, episode_count, total_dataset_amse, normalized_amse = evaluate_jat_model(model, processor, tfds_shards)
 
         # End timing
         end_time = time.time()
@@ -41,6 +55,7 @@ def profile_jat_on_openx():
 
         # Store results
         eval_results[openx_dataset] = {
+            'action_success_rate': action_success_rate,
             'avg_mse_list': avg_mse_list,
             'episode_count': episode_count,
             'total_dataset_amse': total_dataset_amse,
@@ -48,7 +63,27 @@ def profile_jat_on_openx():
             'eval_time': eval_time
         }
 
+        wandb.log({"action_success_rate": action_success_rate, "eval_time": eval_time, "episode_count": episode_count, "total_dataset_amse": total_dataset_amse, "normalized_amse": normalized_amse, "hover_info": f"Dataset: {openx_dataset}"})
+
+        # Save intermediate results to a JSON file to ensure progress is not lost
+        # Check if the file already exists
+        if os.path.exists('jat_openx_evaluation_results.json'):
+            # If it exists, load the existing data
+            with open('jat_openx_evaluation_results.json', 'r') as f:
+                existing_results = json.load(f)
+            # Append new data to existing data
+            existing_results.update(eval_results)
+        else:
+            # If it doesn't exist, use the current eval_results
+            existing_results = eval_results
+
+        # Write the updated or new results to the file
+        with open('jat_openx_evaluation_results.json', 'w') as f:
+            json.dump(existing_results, f, indent=4, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
+
         print(f'Evaluation time for {openx_dataset}: {eval_time:.2f} seconds')
+    
+    wandb.finish()
 
     # Print overall results
     print('\nOverall Results:')
@@ -58,11 +93,7 @@ def profile_jat_on_openx():
         print(f'Total AMSE: {result["total_dataset_amse"]:.4f}')
         print(f'Normalized AMSE: {result["normalized_amse"]:.4f}')
         print(f'Evaluation Time: {result["eval_time"]:.2f} seconds')
-
-    # Save results to a JSON file
-    with open('jat_openx_evaluation_results.json', 'w') as f:
-        json.dump(eval_results, f, indent=4, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
-
+        print(f'Action Success Rate: {result["action_success_rate"]:.4f}')
     print("\nEval results have been saved to 'jat_openx_evaluation_results.json'")
 
 if __name__ == "__main__":

--- a/src/eval/profiling/jat/scripts/profile_openx.py
+++ b/src/eval/profiling/jat/scripts/profile_openx.py
@@ -77,8 +77,6 @@ def profile_jat_on_openx():
             json.dump(existing_results, f, indent=4, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
 
         print(f'Evaluation time for {openx_dataset}: {eval_time:.2f} seconds')
-    
-    wandb.finish()
 
     # Print overall results
     print('\nOverall Results:')

--- a/src/eval/profiling/jat/scripts/profile_openx.py
+++ b/src/eval/profiling/jat/scripts/profile_openx.py
@@ -4,12 +4,9 @@ import json
 from transformers import AutoModelForCausalLM, AutoProcessor
 from jat_openx_eval import evaluate_jat_model
 import numpy as np
-import wandb
 
 def profile_jat_on_openx():
 
-    wandb.login()
-    run = wandb.init(project="jat-openx-eval", id="cc39qjbx", resume="must")
     # Load the model and processor
     model_name_or_path = "jat-project/jat"
     processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True)
@@ -62,8 +59,6 @@ def profile_jat_on_openx():
             'normalized_amse': normalized_amse,
             'eval_time': eval_time
         }
-
-        wandb.log({"action_success_rate": action_success_rate, "eval_time": eval_time, "episode_count": episode_count, "total_dataset_amse": total_dataset_amse, "normalized_amse": normalized_amse, "hover_info": f"Dataset: {openx_dataset}"})
 
         # Save intermediate results to a JSON file to ensure progress is not lost
         # Check if the file already exists


### PR DESCRIPTION
2 modifications:
- Corrected an error in the way episodes were constructed in the dataloader, in cases where an episode ended on the last timestep of a shard.
- Added action success rate as an eval metric - eval code checks whether the predicted action and actual action are equal on the last timestep of an episode, and measures it as a success or failure accordingly.