### PR TITLE
Correction to maintain order in TFDS shards

### DIFF
--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -48,17 +48,11 @@ class OpenXModule:
 
             # Creating the dataloader.
             dataloader = get_openx_dataloader(tfds_shards, batch_size=self.batch_size)
-            # Get the action stats from the dataloader - size of action space, and min, max, mean of each dimension of action space
-
             avg_mse_list = []
             total_dataset_amse = 0.0
             episode_count = 0
             total_success_counts = []
-            action_stats = None
             for batch in dataloader:
-
-                if action_stats is None:
-                    action_stats = dataloader._get_action_stats()
 
                 batch_size = len(batch['text_observation'])
                 episode_mses = [[] for b in range(batch_size)]

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -48,6 +48,7 @@ class OpenXModule:
 
             # Creating the dataloader.
             dataloader = get_openx_dataloader(tfds_shards, batch_size=self.batch_size)
+
             avg_mse_list = []
             total_dataset_amse = 0.0
             episode_count = 0

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -53,7 +53,6 @@ class OpenXModule:
             episode_count = 0
             total_success_counts = []
             for batch in dataloader:
-
                 batch_size = len(batch['text_observation'])
                 episode_mses = [[] for b in range(batch_size)]
                 success_counts = [0 for b in range(batch_size)]
@@ -170,7 +169,6 @@ class OpenXModule:
         assert env_name in DESCRIPTIONS[dataset], f"The environment {env_name} is not included in the OpenX group."
 
         env_desc = ' '.join(DESCRIPTIONS[dataset][env_name])
-
         action_space = ACTION_SPACES[dataset][env_name]
         only_one_action = ACTION_EXCLUSIVENESS[dataset][env_name]
         additional_inst = None


### PR DESCRIPTION
When the shard paths are accumulated for the dataloader, the order of the shards needs to be maintained. This is because there are temporal dependencies between the shards