### PR TITLE
Adding action space statistics

### DIFF
--- a/definitions/prompt.py
+++ b/definitions/prompt.py
@@ -15,13 +15,15 @@ def format_instruction_prompt(env_name: str, env_desc: str, action_space: dict, 
 
     # Making the action description.
     action_desc = [
-        "A discrete action has the available options as key-value pairs, {Option index}: {Option description}. A continuous action has the range of {minimum} ~ {maximum}.",
+        "A discrete action has the available options as key-value pairs, {Option index}: {Option description}. A continuous action has the range of {minimum} ~ {maximum}. A continuous action without a verbal description is described using the statistics of the action space over the entire dataset, which includes the range for each dimension between {minimum} ~ {maximum} and a mean of {mean}.",
     ]
     for idx, tup in action_space.items():
         if len(tup) == 2:  # Discrete
             sent = f"{idx}. {tup[0]} => Discrete. Options: {tup[1]}."
-        else:
+        elif len(tup) == 3:  # Continuous
             sent = f"{idx}. {tup[0]} => Continous. Range: {tup[1]} ~ {tup[2]}."
+        elif len(tup) == 4:  # No verbal description
+            sent = f"{idx}. {tup[0]} => Continuous. Range: {tup[1]} ~ {tup[2]}. Mean: {tup[3]}."
         action_desc.append(sent)
     action_desc = '\n'.join(action_desc) + '\n'
 

--- a/src/data_utils/openx_dataloader.py
+++ b/src/data_utils/openx_dataloader.py
@@ -11,6 +11,10 @@ class OpenXDataset(Dataset):
         self.tfds_shards = tfds_shards
         self.current_elem_idx = 0
         self.current_shard_idx = 0
+        self.action_tensor_size = None
+        self.action_stats = None
+        self.action_stats_populated = False
+        
 
     def _process_shards(self):
         current_episode = []
@@ -121,6 +125,24 @@ class OpenXDataset(Dataset):
                     'reward': elem['reward'].numpy(),
                     'is_last': elem['is_last'].numpy()
                 }
+
+                #Track the min, max, sum, and count of the action space
+                if self.action_tensor_size is None and self.action_stats_populated==False:
+                    self.action_tensor_size = concatenated_action_float.shape
+                if self.action_stats is None and self.action_stats_populated==False:
+                    self.action_stats = {
+                        'min': np.full(self.action_tensor_size, np.inf),
+                        'max': np.full(self.action_tensor_size, -np.inf),
+                        'sum': np.zeros(self.action_tensor_size),
+                        'count': 0
+                    }
+                if self.action_stats_populated==False:
+                    self.action_stats['min'] = np.minimum(self.action_stats['min'], concatenated_action_float)
+                    self.action_stats['max'] = np.maximum(self.action_stats['max'], concatenated_action_float)
+                    self.action_stats['sum'] += concatenated_action_float
+                    self.action_stats['count'] += 1
+                
+
                 
                 current_episode.append(step_data)
 
@@ -140,6 +162,19 @@ class OpenXDataset(Dataset):
             yield current_episode
             current_episode = []
 
+    def _get_action_stats(self):
+        if self.action_stats is None:
+            raise AttributeError("action_stats is None, it has not been populated yet")
+        if self.action_stats['count'] == 0:
+            raise ValueError("No actions have been processed yet")
+        return {
+            'min': self.action_stats['min'],
+            'max': self.action_stats['max'],
+            'mean': self.action_stats['sum'] / self.action_stats['count'],
+            'size': self.action_tensor_size
+        }
+        
+
     def _get_feature(self, elem, feature_name: str) -> Any:
         # Implement feature extraction based on your TFDS structure
         # This is a placeholder and needs to be adjusted based on your data
@@ -149,7 +184,9 @@ class OpenXDataset(Dataset):
             return None
 
     def __len__(self) -> int:
-        return sum(1 for _ in self._process_shards())
+        length =sum(1 for _ in self._process_shards())
+        self.action_stats_populated = True
+        return length
 
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         if idx == 0:    
@@ -217,7 +254,7 @@ def custom_collate(batch):
 
 def get_openx_dataloader(tfds_shards: List[str], batch_size: int, num_workers: int = 0) -> DataLoader:
     dataset = OpenXDataset(tfds_shards)
-    return DataLoader(
+    return dataset, DataLoader(
         dataset,
         batch_size=batch_size,
         shuffle=False,

--- a/src/data_utils/openx_dataloader.py
+++ b/src/data_utils/openx_dataloader.py
@@ -165,8 +165,8 @@ class OpenXDataset(Dataset):
     def _get_action_stats(self):
         if self.action_stats is None:
             raise AttributeError("action_stats is None, it has not been populated yet")
-        if self.action_stats['count'] == 0:
-            raise ValueError("No actions have been processed yet")
+        if self.action_stats_populated == False:
+            raise ValueError("Action stats population is not finished yet.")
         return {
             'min': self.action_stats['min'],
             'max': self.action_stats['max'],


### PR DESCRIPTION
This PR includes the addition of code to calculate action space statistics across an entire dataset, and use this information in the action description of the prompt as a fallback for datasets that do not have verbal descriptions of the action space.

Changes:

prompt.py:
- Include the new action category for the prompt (continuous action spaces without verbal descriptions)

openx_dataloader.py:
- Track the action space statistics as a one-time calculation for each dataset, when the PyTorch dataloader intrinsically calls the __len__ function
- Function to return the action statistics
- Return the OpenXDataset object along with the dataloader in order to access the action stats

openx_module.py:
- Obtains the action states before creating the prompt
- Checks the action description to see if there is a placeholder (currently following @KickItLikeShika's placeholder format) that indicates the absence of a verbal description --> creates a an action space description tuple based on the statistics --> passes this new description to the prompt formatting function