### PR TITLE
Adding first set of action space descriptions and corresponding changes

### DIFF
--- a/definitions/openx.py
+++ b/definitions/openx.py
@@ -1194,7 +1194,8 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
+            7: ("Termination", {1: "Yes", 0: "No"})
         },
         "sweep the green cloth to the left side of the table": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1203,7 +1204,8 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
+            7: ("Termination", {1: "Yes", 0: "No"})
         },
         "pick up the blue cup and put it into the brown cup": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1212,7 +1214,8 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
+            7: ("Termination", {1: "Yes", 0: "No"})
         },
         "put the ranch bottle into the pot": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1221,7 +1224,8 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
+            7: ("Termination", {1: "Yes", 0: "No"})
         }
     },
     "fractal20220817_data": {

--- a/definitions/openx.py
+++ b/definitions/openx.py
@@ -3234,19 +3234,19 @@ ACTION_EXCLUSIVENESS = {
 ADDITIONAL_INSTRUCTIONS = {
     "berkeley_autolab_ur5": {
         "take the tiger out of the red bowl and put it in the grey bowl": [
-            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "sweep the green cloth to the left side of the table": [
-            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "pick up the blue cup and put it into the brown cup": [
-            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "put the ranch bottle into the pot": [
-            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ]
     }

--- a/definitions/openx.py
+++ b/definitions/openx.py
@@ -1194,8 +1194,7 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
-            7: ("Termination", {1: "Yes", 0: "No"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
         },
         "sweep the green cloth to the left side of the table": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1204,8 +1203,7 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
-            7: ("Termination", {1: "Yes", 0: "No"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
         },
         "pick up the blue cup and put it into the brown cup": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1214,8 +1212,7 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
-            7: ("Termination", {1: "Yes", 0: "No"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
         },
         "put the ranch bottle into the pot": {
             0: ("The delta change in X axis with respect to the robot base frame", -0.02, 0.02),
@@ -1224,182 +1221,540 @@ ACTION_SPACES = {
             3: ("The delta change in roll with respect to the robot base frame", -0.06666666666, 0.06666666666),
             4: ("The delta change in pitch with respect to the robot base frame", -0.06666666666, 0.06666666666),
             5: ("The delta change in yaw with respect to the robot base frame", -0.06666666666, 0.06666666666),
-            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"}),
-            7: ("Termination", {1: "Yes", 0: "No"})
+            6: ("The delta change in gripper closing action", {1: "Gripper closing from an open state", -1: "Gripper opening from a closed state", 0: "No change"})
         }
     },
     "fractal20220817_data": {
         "pick and place items": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "move object near another object": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "place objects up-right": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "open a drawer": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "close a drawer": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "place object into receptacle": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         },
         "pick object into receptacle and place on the counter": {
-            0: None
+            0: ("Gripper of the robot closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+            1: ("X axis displacement for the robot's arm movement"),
+            2: ("Y axis displacement for the robot's arm movement"),
+            3: ("Z axis displacement for the robot's arm movement"),
+            4: ("Roll displacement for the robot's arm movement"),
+            5: ("Pitch displacement for the robot's arm movement"),
+            6: ("Yaw displacement for the robot's arm movement"),
+            7: ("Yaw displacement for the robot's base movement"),
+            8: ("X axis displacement for the robot's base movement"),
+            9: ("Y axis displacement for the robot's base movement")
         }
     },
     "kuka": {
         "grasp and pick an object": {
-            0: None
+           0: ("Gripper closed or open", {1.0: "Gripper closed", 0.0: "Gripper open"}),
+           1: ("X axis displacement of the robot gripper pose in meters", -1, 1),
+           2: ("Y axis displacement of the robot gripper pose in meters", -1, 1),
+           3: ("Z axis displacement of the robot gripper pose in meters", -1, 1),
+           4: ("The delta change in roll of the robot gripper pose in radians", 0, 0.6366),
+           5: ("The delta change in pitch of the robot gripper pose in radians", 0, 0.6366),
+           6: ("The delta change in yaw of the robot gripper pose in radians", 0, 0.6366),
+           7: ("The displacement in vertical rotation of the robot base in radians", 0, 0.6366),
+           8: ("X axis displacement of the robot base in meters", -1, 1),
+           9: ("Y axis displacement of the robot base in meters", -1, 1)
         }
     },
     "bridge": {
         "put corn in pot": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1.0: "The robot has reached the target location", 0.0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1.0: "Gripper open", 0.0: "Gripper closed"})
         },
         "put carrot on plate": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "push": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "reorient objects": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "sweep": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "open door": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "Open drawer": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "close door": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "close drawer": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "stack blocks": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "fold thin blue cloth over object": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "fold thick gray cloth over object": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "wipe a surface": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "twist knobs": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "flip a switch": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "turn faucets": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         },
         "zip a zipper": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("The delta change in the roll for the robot"),
+            4: ("The delta change in the pitch for the robot"),
+            5: ("The delta change in the yaw for the robot"),
+            6: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            7: ("Open or close the gripper", {1: "Gripper open", 0: "Gripper closed"})
         }
     },
     "taco_play": {
         "rotate block left": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "rotate block right": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "push block left": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "push block right": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "lift the block on top of the drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "lift the block inside the drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "lift the block from the slider": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "lift the block from the container": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "lift the block from the table": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "place the block on top of the drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "place the block inside the drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "place the block in the slider": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "place the block in the container": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "stack objects": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "unstack objects": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "open drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "close drawer": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "move slider left": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "move slider right": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn red light on": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn red light off": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn green light on": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn green light off": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn blue light on": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         },
         "turn blue light off": {
-            0: None
+            0: ("X axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            1: ("Y axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            2: ("Z axis displacement for the end effector of the robot in 3D space",-1.0, 1.0),
+            3: ("X axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            4: ("Y axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            5: ("Z axis displacement for the end effector of the robot in the robot's base frame", -1.0, 1.0),
+            6: ("Open or close the gripper", {-1.0: "Gripper open", 1.0: "Gripper closed"})
         }
     },
     "jaco_play": {
         "pick up an object": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("Gripper closed or open or doesn't move", {2.0: "Gripper closed", 0.0: "Gripper open", 1.0: "Gripper doesn't move"})
         },
         "put an object down": {
-            0: None
+            0: ("X axis displacement for the robot"),
+            1: ("Y axis displacement for the robot"),
+            2: ("Z axis displacement for the robot"),
+            3: ("Gripper closed or open or doesn't move", {2.0: "Gripper closed", 0.0: "Gripper open", 1.0: "Gripper doesn't move"})
         }
     },
     "berkeley_cable_routing": {
         "pick up an object": {
-            0: None
+            0: ("The delta X axis rotation delta with respect to the robot's end effector frame"),
+            1: ("The delta Y axis rotation delta with respect to the robot's end effector frame"),
+            2: ("The delta Z axis rotation delta with respect to the robot's end effector frame"),
+            3: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            4: ("The X axis displacement with respect to the robot's end effector frame"),
+            5: ("The Y axis displacement with respect to the robot's end effector frame"),
+            6: ("The Z axis displacement with respect to the robot's end effector frame")
         },
         "route a cable": {
-            0: None
+            0: ("The X axis rotation delta with respect to the robot's end effector frame"),
+            1: ("The Y axis rotation delta with respect to the robot's end effector frame"),
+            2: ("The Z axis rotation delta with respect to the robot's end effector frame"),
+            3: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            4: ("The X axis displacement with respect to the robot's end effector frame"),
+            5: ("The Y axis displacement with respect to the robot's end effector frame"),
+            6: ("The Z axis displacement with respect to the robot's end effector frame")
         }
     },
     "roboturk": {
@@ -1415,24 +1770,66 @@ ACTION_SPACES = {
     },
     "nyu_door_opening_surprising_effectiveness": {
         "push objects": {
-            0: None
+            0: ("The X axis displacement in meters of the robot"),
+            1: ("The Y axis displacement in meters of the robot"),
+            2: ("The Z axis displacement in meters of the robot"),
+            3: ("Width of the gripper fingertips describing how open it is", 0.0, 3.0),
+            4: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            5: ("The X axis rotation delta of the robot in Euler coordinates"),
+            6: ("The Y axis rotation delta of the robot in Euler coordinates"),
+            7: ("The Z axis rotation delta of the robot in Euler coordinates")
         },
         "stack objects": {
-            0: None
+            0: ("The X axis displacement in meters of the robot"),
+            1: ("The Y axis displacement in meters of the robot"),
+            2: ("The Z axis displacement in meters of the robot"),
+            3: ("Width of the gripper fingertips describing how open it is", 0.0, 3.0),
+            4: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            5: ("The X axis rotation delta of the robot in Euler coordinates"),
+            6: ("The Y axis rotation delta of the robot in Euler coordinates"),
+            7: ("The Z axis rotation delta of the robot in Euler coordinates")
         },
         "open door": {
-            0: None
+            0: ("The X axis displacement in meters of the robot"),
+            1: ("The Y axis displacement in meters of the robot"),
+            2: ("The Z axis displacement in meters of the robot"),
+            3: ("Width of the gripper fingertips describing how open it is", 0.0, 3.0),
+            4: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            5: ("The X axis rotation delta of the robot in Euler coordinates"),
+            6: ("The Y axis rotation delta of the robot in Euler coordinates"),
+            7: ("The Z axis rotation delta of the robot in Euler coordinates")
         }
     },
     "viola": {
         "sort": {
-            0 : None
+            0 : ("Gripper closed or open", {-1.0: "Gripper open", 1.0: "Gripper closed"}),
+            1: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            2: ("The X axis displacement of the robot"),
+            3: ("The Y axis displacement of the robot"),
+            4: ("The Z axis displacement of the robot"),
+            5: ("The X axis rotation delta of the robot"),
+            6: ("The Y axis rotation delta of the robot"),
+            7: ("The Z axis rotation delta of the robot")
         },
         "BUDS kitchen": {
-            0: None
+            0 : ("Gripper closed or open", {-1.0: "Gripper open", 1.0: "Gripper closed"}),
+            1: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            2: ("The X axis displacement of the robot"),
+            3: ("The Y axis displacement of the robot"),
+            4: ("The Z axis displacement of the robot"),
+            5: ("The X axis rotation delta of the robot"),
+            6: ("The Y axis rotation delta of the robot"),
+            7: ("The Z axis rotation delta of the robot")
         },
         "stack": {
-            0: None
+            0 : ("Gripper closed or open", {-1.0: "Gripper open", 1.0: "Gripper closed"}),
+            1: ("Termination", {1: "The robot has reached the target location", 0: "The robot has not reached the target location"}),
+            2: ("The X axis displacement of the robot"),
+            3: ("The Y axis displacement of the robot"),
+            4: ("The Z axis displacement of the robot"),
+            5: ("The X axis rotation delta of the robot"),
+            6: ("The Y axis rotation delta of the robot"),
+            7: ("The Z axis rotation delta of the robot")
         }
     },
     "toto": {
@@ -1445,34 +1842,45 @@ ACTION_SPACES = {
     },
     "language_table": {
         "push the yellow hexagon to the top right corner": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
+
         },
         "push the red circle to the bottom right corner": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "push the green star to the bottom left corner": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "move the yellow heart to the yellow hexagon": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "move the red star to the red circle": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "nudge the green star down and left a bit": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "nudge the green circle closer to the green star": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "put objects": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "touch objects": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         },
         "slide objects": {
-            0: None
+            0: ("X axis co-ordinate in the Cartesian setpoint of the end effector"),
+            1: ("Y axis co-ordinate in the Cartesian setpoint of the end effector")
         }
     },
     "columbia_cairlab_pusht_real": {
@@ -2822,19 +3230,19 @@ ACTION_EXCLUSIVENESS = {
 ADDITIONAL_INSTRUCTIONS = {
     "berkeley_autolab_ur5": {
         "take the tiger out of the red bowl and put it in the grey bowl": [
-            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "sweep the green cloth to the left side of the table": [
-            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "pick up the blue cup and put it into the brown cup": [
-            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ],
         "put the ranch bottle into the pot": [
-            "The robot state represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
+            "The continuous observation represents [joint0, joint1, joint2, joint3, joint4, joint5, x, y, z, qx, qy, qz, qw, gripper_is_closed, action_blocked].",
             "action_blocked is binary: 1 if the gripper opening/closing action is being executed and no other actions can be performed; 0 otherwise."
         ]
     }

--- a/definitions/prompt.py
+++ b/definitions/prompt.py
@@ -22,7 +22,7 @@ def format_instruction_prompt(env_name: str, env_desc: str, action_space: dict, 
             sent = f"{idx}. {tup[0]} => Discrete. Options: {tup[1]}."
         elif len(tup) == 3:  # Continuous
             sent = f"{idx}. {tup[0]} => Continous. Range: {tup[1]} ~ {tup[2]}."
-        elif len(tup) == 4:  # No verbal description
+        elif len(tup) == 4:  # No verbal description or just verbal description with no stats
             sent = f"{idx}. {tup[0]} => Continuous. Range: {tup[1]} ~ {tup[2]}. Mean: {tup[3]}."
         action_desc.append(sent)
     action_desc = '\n'.join(action_desc) + '\n'

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -236,6 +236,13 @@ class OpenXModule:
                 ACTION_SPACES[dataset][env_name] = {}
                 for i in range(self.action_stats_opxmodule['size'][0]):
                     ACTION_SPACES[dataset][env_name][i] = ("The action space statistics of this dimension of the action space over the entire dataset", self.action_stats_opxmodule['min'][i], self.action_stats_opxmodule['max'][i], self.action_stats_opxmodule['mean'][i])
+        
+        elif len(ACTION_SPACES[dataset][env_name]) != 1:
+            # For cases where the verbal description is present but not the ranges, so we augment the information given with the stats
+            for i in range(self.action_stats_opxmodule['size'][0]):
+                if len(ACTION_SPACES[dataset][env_name][i]) == 1:
+                    ACTION_SPACES[dataset][env_name][i] = (ACTION_SPACES[dataset][env_name][i][0]+". In addition to this verbal description, here are the action space statistics of this dimension over the entire dataset", self.action_stats_opxmodule['min'][i], self.action_stats_opxmodule['max'][i], self.action_stats_opxmodule['mean'][i])
+        
         action_space = ACTION_SPACES[dataset][env_name]
         only_one_action = ACTION_EXCLUSIVENESS[dataset][env_name]
         additional_inst = None


### PR DESCRIPTION
This PR includes the addition of a few verbal descriptions of the action spaces and changes in supporting scripts to use them.

definitions/openx.py:
- Added action space descriptions for 9 new datasets. Only very few of them had the ranges of each dimension available.

definitions/prompt.py:
- Minor change in comment for better readability and understanding

src/modules/dataset_modules/openx_module.py
- Checking if a given dimension of an action space for a given dataset and env has only 1 element in the tuple - which would mean that there is only a verbal description but no ranges available. In this case, augment it with statistics instead of the range, before passing to the prompt creation function.

To-do:
Once this is approved and merged, will add more descriptions from the set that @KickItLikeShika and I have collected.