### PR TITLE
Adding new GPT profiling results and minor modifications to dataloaders and GPT's openx module

### DIFF
--- a/src/data_utils/openx_dataloader.py
+++ b/src/data_utils/openx_dataloader.py
@@ -58,12 +58,17 @@ class OpenXDataset(Dataset):
                     elem['observation'] = dict(sorted(elem['observation'].items()))
                     for key, tensor in elem['observation'].items():
                         if 'language' not in key and 'image' not in key and 'pointcloud' not in key and 'rgb' not in key and 'instruction' not in key:
-                            float_obs[key] = tensor.numpy()
+                            if (tensor.dtype == tf.float32 or tensor.dtype==tf.float64) and tensor.shape.ndims>=1 and not tf.reduce_any(tf.math.is_inf(tensor)):
+                                float_obs[key] = tensor.numpy()
 
                 #Processing image observation
                 image_observation = None
                 if 'image' in elem['observation']:
                     image_observation = elem['observation']['image'].numpy().astype(np.uint8)
+                elif 'hand_image' in elem['observation']:
+                    image_observation = elem['observation']['hand_image'].numpy().astype(np.uint8)
+                elif 'wrist_image' in elem['observation']:
+                    image_observation = elem['observation']['wrist_image'].numpy().astype(np.uint8)
                 elif 'rgb' in elem['observation']:
                     image_observation = elem['observation']['rgb'].numpy().astype(np.uint8)
 

--- a/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_1.json
+++ b/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_1.json
@@ -1,0 +1,34 @@
+{
+    "berkeley_autolab_ur5": {
+        "action_success_rate": 1.9230769230769231,
+        "total_dataset_amse": 749.620213080081,
+        "num_timesteps": 10156,
+        "avg_dataset_amse": 0.0738105763174558,
+        "normalized_amse": 0.04878093800424255,
+        "eval_time": 28951.873731136322
+    },
+    "jaco_play": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 5802.75007643194,
+        "num_timesteps": 7838,
+        "avg_dataset_amse": 0.7403355545332917,
+        "normalized_amse": 0.3139787491625979,
+        "eval_time": 15151.50432395935
+    },
+    "columbia_cairlab_pusht_real": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 85.23943457701799,
+        "num_timesteps": 2884,
+        "avg_dataset_amse": 0.029555975928230924,
+        "normalized_amse": 0.04634220551303001,
+        "eval_time": 5309.376355409622
+    },
+    "toto": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 11396.57027407351,
+        "num_timesteps": 31560,
+        "avg_dataset_amse": 0.3611080568464357,
+        "normalized_amse": 0.0688690727925556,
+        "eval_time": 76075.78347039223
+    }
+}

--- a/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_2.json
+++ b/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_2.json
@@ -1,0 +1,42 @@
+{
+    "utokyo_pr2_opening_fridge_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 40676339.367871605,
+        "num_timesteps": 2382,
+        "avg_dataset_amse": 17076.54885301075,
+        "normalized_amse": 0.03979190668248023,
+        "eval_time": 4304.931730508804
+    },
+    "conq_hose_manipulation": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 247.15185113743664,
+        "num_timesteps": 1944,
+        "avg_dataset_amse": 0.1271357258937431,
+        "normalized_amse": 0.02404198702143704,
+        "eval_time": 2418.9575979709625
+    },
+    "utokyo_pr2_tabletop_manipulation_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 17359589.74426715,
+        "num_timesteps": 6362,
+        "avg_dataset_amse": 2728.637180802759,
+        "normalized_amse": 0.017474166367328643,
+        "eval_time": 12327.510221004486
+    },
+    "stanford_mask_vit_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 1820.202144692518,
+        "num_timesteps": 2821,
+        "avg_dataset_amse": 0.6452329474273372,
+        "normalized_amse": 0.11953495148117718,
+        "eval_time": 5767.387697219849
+    },
+    "plex_robosuite": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 4284.097465739796,
+        "num_timesteps": 9096,
+        "avg_dataset_amse": 0.4709869685290013,
+        "normalized_amse": 0.06660421777177758,
+        "eval_time": 15759.11651968956
+    }
+}

--- a/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_3.json
+++ b/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_3.json
@@ -1,0 +1,34 @@
+{
+    "nyu_rot_dataset_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 153.30585278734344,
+        "num_timesteps": 440,
+        "avg_dataset_amse": 0.34842239269850783,
+        "normalized_amse": 0.030033881285239043,
+        "eval_time": 735.1687004566193
+    },
+    "ucsd_pick_and_place_dataset_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 8989.84246231718,
+        "num_timesteps": 13824,
+        "avg_dataset_amse": 0.6503068910819719,
+        "normalized_amse": 0.0858786618437778,
+        "eval_time": 24392.52116584778
+    },
+    "ucsd_kitchen_dataset_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 4935753.94652446,
+        "num_timesteps": 386,
+        "avg_dataset_amse": 12786.927322602227,
+        "normalized_amse": 0.16242289460882187,
+        "eval_time": 1046.0351450443268
+    },
+    "stanford_hydra_dataset_converted_externally_to_rlds": {
+        "action_success_rate": 0.8333333333333334,
+        "total_dataset_amse": 14500.662948832163,
+        "num_timesteps": 72192,
+        "avg_dataset_amse": 0.20086246327615476,
+        "normalized_amse": 0.009134259793548635,
+        "eval_time": 142744.80327630043
+    }
+}

--- a/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_4.json
+++ b/src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_4.json
@@ -1,0 +1,10 @@
+{
+    "kaist_nonprehensile_converted_externally_to_rlds": {
+        "action_success_rate": 0.0,
+        "total_dataset_amse": 9029807476.203888,
+        "num_timesteps": 6656,
+        "avg_dataset_amse": 1356641.7482277476,
+        "normalized_amse": 0.00015089337797499446,
+        "eval_time": 24580.76447057724
+    }
+}

--- a/src/eval/profiling/jat/scripts/openx_dataloader.py
+++ b/src/eval/profiling/jat/scripts/openx_dataloader.py
@@ -130,6 +130,15 @@ class OpenXDataset(Dataset):
                     elif img_obs.shape[2] == 2:
                         img_4channel = np.dstack((img_obs, img_obs))
                         img_obs_pil = Image.fromarray(img_4channel)
+                elif 'wrist_image' in elem['observation']:
+                    img_obs = elem['observation']['wrist_image'].numpy().astype(np.uint8)
+                    if img_obs.shape[2] == 3:
+                        fourth_channel = img_obs[:,:,0]  # Use the red channel as the fourth channel
+                        img_4channel = np.dstack((img_obs, fourth_channel))
+                        img_obs_pil = Image.fromarray(img_4channel)
+                    elif img_obs.shape[2] == 2:
+                        img_4channel = np.dstack((img_obs, img_obs))
+                        img_obs_pil = Image.fromarray(img_4channel)
                 elif 'rgb' in elem['observation']:
                     img_obs = elem['observation']['rgb'].numpy().astype(np.uint8)
                     if img_obs.shape[2] == 3:


### PR DESCRIPTION
JAT dataloader (src/eval/profiling/jat/scripts/openx_dataloader.py):
- Adding key 'wrist_image' as one of the possible descriptors for image observation in an OpenX dataset

GPT dataloader (src/data_utils/openx_dataloader.py):
- Utilizing only float point observation states to keep it similar to JAT
- Adding keys 'hand_image' and 'wrist_image' as possible descriptors for image observation in an OpenX dataset

GPT Openx module (src/modules/dataset_modules/openx_module.py):
- Adding functionality to save results after each dataset's profiling is complete, and pick up profiling after completed datasets if restarted
- Modifying metrics from episode-wise to timestep-wise
- Adding more cases for GPT output handling

GPT profiling results (src/eval/profiling/gpt_results/final_zero_shot_results/gpt_openx_results_bucket_*)
- Adding 14 new GPT profiling results on OpenX