### PR TITLE
RL Unplugged modules - TFDS and GCP download method

### DIFF
--- a/src/centralized_downloader.py
+++ b/src/centralized_downloader.py
@@ -32,7 +32,6 @@ def rlu_tfds(dataset_name: str, output_dir: str):
 
     rlu_dmcs_dataset_list = ['rlu_control_suite/cartpole_swingup', 'rlu_control_suite/cheetah_run', 'rlu_control_suite/finger_turn_hard', 'rlu_control_suite/fish_swim', 'rlu_control_suite/humanoid_run', 'rlu_control_suite/manipulator_insert_ball', 'rlu_control_suite/manipulator_insert_peg', 'rlu_control_suite/walker_stand', 'rlu_control_suite/walker_walk']
 
-    tfds.display_progress_bar(enable=True)
     for dataset in rlu_dmcs_dataset_list:
 
         # Download the dataset and retrieve dataset information

--- a/src/centralized_downloader.py
+++ b/src/centralized_downloader.py
@@ -30,9 +30,9 @@ def build_arg_parser() -> ArgumentParser:
 #Make sure you have sufficient memory to download the dataset. During the TFDS load function, the entire dataset is loaded into memory. Check the sizes at https://www.tensorflow.org/datasets/catalog/rlu_control_suite
 def rlu_tfds(dataset_name: str, output_dir: str):
 
-    #rlu_dmlab_dataset_list = ['rlu_dmlab_explore_object_rewards_few', 'rlu_dmlab_explore_object_rewards_many', 'rlu_dmlab_rooms_select_nonmatching_object', 'rlu_dmlab_rooms_watermaze', 'rlu_dmlab_seekavoid_arena01']
     rlu_dmcs_dataset_list = ['rlu_control_suite/cartpole_swingup', 'rlu_control_suite/cheetah_run', 'rlu_control_suite/finger_turn_hard', 'rlu_control_suite/fish_swim', 'rlu_control_suite/humanoid_run', 'rlu_control_suite/manipulator_insert_ball', 'rlu_control_suite/manipulator_insert_peg', 'rlu_control_suite/walker_stand', 'rlu_control_suite/walker_walk']
 
+    tfds.display_progress_bar(enable=True)
     for dataset in rlu_dmcs_dataset_list:
 
         # Download the dataset and retrieve dataset information
@@ -40,15 +40,13 @@ def rlu_tfds(dataset_name: str, output_dir: str):
             dataset,
             split='train',
             data_dir=output_dir,
+            #batch_size = 2,
             download=True,
             with_info=True
         )
 
         print("Dataset downloaded and stored at:", output_dir)
         print("Dataset information:", info)
-
-
-
 
 
 # RL unplugged
@@ -400,6 +398,8 @@ def download_datasets(dataset_name: str, output_dir: str):
     if dataset_name in ['obelics','coyo_700m', 'ms_coco_captions', 'conceptual_captions', 'a_okvqa', 'vqa_v2', 'datacomp', 'finewebedu']:
         vislang(dataset_name, output_dir)
     elif dataset_name == 'dm_lab_rlu' or dataset_name == 'dm_control_suite_rlu':
+        rlu(dataset_name, output_dir)
+    elif dataset_name == 'dm_lab_rlu_tfds' or dataset_name == 'dm_control_suite_rlu_tfds':
         rlu_tfds(dataset_name, output_dir)
     elif dataset_name == 'atari' or dataset_name == 'mujoco' or dataset_name == 'babyai' or dataset_name == 'metaworld':
         jat(dataset_name, output_dir)

--- a/src/control_translation/centralized_translation.py
+++ b/src/control_translation/centralized_translation.py
@@ -74,10 +74,12 @@ def rlu_tfds(dataset_path: str, limit_schema: bool, output_dir, dataset_name):
     except:
         raise ValueError('Enter the correct path to a DM Lab or DM Control Suite file downloaded from RL unplugged using TFDS. It should be in the format rlu_control_suite/cartpole_swingup')
 
-    #print(tfds_name)
+    print(tfds_name)
 
     #Data dir needs to be the parent directory of the dataset path
     data_dir = dataset_path.split('/')[0] if '/' in dataset_path else '.'
+    print('\nData dir:')
+    print(data_dir)
     #print(data_dir)
     #Load the TFDS dataset
     loaded_dataset = tfds.load(
@@ -86,6 +88,8 @@ def rlu_tfds(dataset_path: str, limit_schema: bool, output_dir, dataset_name):
     data_dir=data_dir,
     download=False
     )
+
+    print('\nLoaded dataset')
 
     count=0
     
@@ -145,8 +149,7 @@ def rlu(dataset_path: str, limit_schema: bool):
         print('Enter the correct path to a DM Lab or DM Control Suite file downloaded from RL unplugged')
         return None
 
-    #Access the values in the dataset based on the feature type --only accessing 5 episodes with this code (remove .take() if entire ds needs to be downloaded)
-    for raw_record in raw_dataset.take(5):
+    for raw_record in raw_dataset:
 
         example = tf.train.Example()
         example.ParseFromString(raw_record.numpy())
@@ -199,7 +202,6 @@ def rlu(dataset_path: str, limit_schema: bool):
     print('Translating...')
     dm_lab_tfds = tf.data.Dataset.from_tensor_slices(dm_lab_dict)
     return dm_lab_tfds
-    
 
 # JAT datasets translation
 def jat(dataset_name: str, dataset_path: str, hf_test_data: bool, limit_schema: bool):
@@ -416,6 +418,8 @@ def categorize_datasets(dataset_name: str, dataset_path: str, hf_test_data: bool
         if dataset_name=='dm_lab_rlu' or dataset_name=='dm_control_suite_rlu':
             translated_ds = rlu(dataset_path, limit_schema)
             return translated_ds
+        elif dataset_name=='dm_lab_rlu_tfds' or dataset_name=='dm_control_suite_rlu_tfds':
+            rlu_tfds(dataset_path, limit_schema, args.output_dir, dataset_name)
         elif dataset_name=='baby_ai' or dataset_name=='ale_atari' or dataset_name=='mujoco' or dataset_name=='meta_world':
             translated_ds = jat(dataset_name, dataset_path, hf_test_data, limit_schema)
             return translated_ds

--- a/src/control_translation/centralized_translation.py
+++ b/src/control_translation/centralized_translation.py
@@ -74,12 +74,8 @@ def rlu_tfds(dataset_path: str, limit_schema: bool, output_dir, dataset_name):
     except:
         raise ValueError('Enter the correct path to a DM Lab or DM Control Suite file downloaded from RL unplugged using TFDS. It should be in the format rlu_control_suite/cartpole_swingup')
 
-    print(tfds_name)
-
     #Data dir needs to be the parent directory of the dataset path
     data_dir = dataset_path.split('/')[0] if '/' in dataset_path else '.'
-    print('\nData dir:')
-    print(data_dir)
     #print(data_dir)
     #Load the TFDS dataset
     loaded_dataset = tfds.load(
@@ -178,9 +174,15 @@ def rlu(dataset_path: str, limit_schema: bool):
                 dm_lab_dict[key].append(values)
             else:
                 print(f"Unsupported feature type: {key}")
-        
+
     #Convert data dict to TFDS
-    dm_lab_dict = {k: tf.convert_to_tensor(v) for k, v in dm_lab_dict.items()}
+    dm_lab_dict_new = {}
+    for k, v in dm_lab_dict.items():
+        if k != 'observations_pixels':
+            dm_lab_dict_new[k] = tf.convert_to_tensor(v)
+        else:
+            dm_lab_dict_new[k] = tf.ragged.stack(v)
+
 
     # Trim the data if limit_schema flag is set during code execution
     if limit_schema:
@@ -200,7 +202,7 @@ def rlu(dataset_path: str, limit_schema: bool):
         return dm_lab_dict_trimmed_tfds
 
     print('Translating...')
-    dm_lab_tfds = tf.data.Dataset.from_tensor_slices(dm_lab_dict)
+    dm_lab_tfds = tf.data.Dataset.from_tensor_slices(dm_lab_dict_new)
     return dm_lab_tfds
 
 # JAT datasets translation

--- a/src/control_translation/tests/testrlu.py
+++ b/src/control_translation/tests/testrlu.py
@@ -7,43 +7,33 @@ import numpy as np
 import os
 import time
 
-class TestRLUToTFDS(unittest.TestCase):
+class TestRLUTranslation(unittest.TestCase):
     
     def setUp(self):
         start_time = time.time()
         # Load a sample RLU dataset
-        self.rlu_dataset = tfds.load(
-            'rlu_control_suite/cartpole_swingup',
-            split='train',
-            data_dir='../../rlu_control_suite/cartpole_swingup',
-            download=False
-        )
+        self.rlu_dataset = tf.data.TFRecordDataset('../../dmlab/explore_object_rewards_few/training_0/tfrecord-00000-of-00500', compression_type='GZIP')
         print(f'Time taken for RLU dataset load: {time.time() - start_time} seconds')
         
-        # Load first 3 episodes of translated TFDS dataset
+        # Load translated TFDS dataset
         start_time = time.time()
-        self.tfds_dataset_ep_1 = tf.data.Dataset.load('../dm_control_suite_rlu_translated/rlu_control_suite/cartpole_swingup/translated_episode_1')
-        self.tfds_dataset_ep_40 = tf.data.Dataset.load('../dm_control_suite_rlu_translated/rlu_control_suite/cartpole_swingup/translated_episode_40')
-        self.tfds_dataset_ep_17 = tf.data.Dataset.load('../dm_control_suite_rlu_translated/rlu_control_suite/cartpole_swingup/translated_episode_17')
+        self.tfds_dataset = tf.data.Dataset.load('../dm_lab_rlu_translated')
         print(f'Time taken for translated dataset load: {time.time() - start_time} seconds')
 
     def test_dataset_sizes_match(self):
         """Test that datasets have same number of examples"""
         start_time = time.time()
-        rlu_lens = 0
-        tfds_lens = 0
         
-        # Get lengths from RLU dataset
-        for episode in self.rlu_dataset:
-            rlu_lens += 1
-             
-        # Count the number of translated episode files
-        translated_dir = '../dm_control_suite_rlu_translated/rlu_control_suite/cartpole_swingup/'
-        tfds_lens = len([f for f in os.listdir(translated_dir) if f.startswith('translated_')])
+        rlu_count = sum(1 for _ in self.rlu_dataset)
+        tfds_count = sum(1 for _ in self.tfds_dataset)
 
-        self.assertGreater(rlu_lens, 0)
-        self.assertGreater(tfds_lens, 0)
-        self.assertEqual(rlu_lens, tfds_lens)
+        #print(rlu_count)
+        #print(tfds_count)
+
+        self.assertGreater(rlu_count, 0)
+        self.assertGreater(tfds_count, 0) 
+        self.assertEqual(rlu_count, tfds_count)
+        
         print(f'Time taken for dataset size test: {time.time() - start_time} seconds')
 
     def test_feature_names_match(self):
@@ -52,44 +42,31 @@ class TestRLUToTFDS(unittest.TestCase):
         
         # Get RLU feature names
         rlu_features = set()
-        for episode in self.rlu_dataset:
-            for key in episode.keys():
-                if key == 'steps':
-                    # Handle steps variant dataset
-                    for step in episode[key]:
-                        #print(step.keys())
-                        for step_key in step.keys():      
-
-                            rlu_features.add(f'steps/{step_key}')
-                        
-                        break
-                else:
-                    rlu_features.add(key)
+        for raw_record in self.rlu_dataset:
+            example = tf.train.Example()
+            example.ParseFromString(raw_record.numpy())
+            for key in example.features.feature:
+                rlu_features.add(key)
             break
 
         # Get translated feature names
         tfds_features = set()
-        for episode in self.tfds_dataset_ep_1:
-            for key in episode.keys():
-                if key == 'steps':
-                    for step_number in episode[key]:
-                        #print('\nCHECK')
-                        #print(episode[key][step_number].keys())
-                        for step_key in episode[key][step_number].keys():
-                            tfds_features.add(f'steps/{step_key}')
-                        break
-                    
-                else:
-                    tfds_features.add(key)
+        for element in self.tfds_dataset:
+            for key in element.keys():
+                tfds_features.add(key)
             break
 
+        print(rlu_features)
+        print(tfds_features)
         self.assertEqual(rlu_features, tfds_features)
         print(f'Time taken for feature names test: {time.time() - start_time} seconds')
 
     def test_data_values_match(self):
+        """Test that data values are preserved"""
+        start_time = time.time()
 
         def test_values_match(rlu_values, tfds_values):
-        # Compare values between RLU and TFDS datasets
+            # Compare values between RLU and TFDS datasets
             for key in rlu_values.keys():
                 self.assertIn(key, tfds_values, f"Key {key} missing from translated dataset")
                 
@@ -109,193 +86,77 @@ class TestRLUToTFDS(unittest.TestCase):
                     else:
                         self.assertEqual(rlu_val, tfds_val,
                                     f"Value mismatch for {key}[{i}]: RLU={rlu_val}, TFDS={tfds_val}")
-        
-        start_time = time.time()
-        
-        # Compare first episode
 
-        tfds_ele = next(iter(self.tfds_dataset_ep_1))
-        rlu_ele = self.rlu_dataset
 
-        #Compare values of first episode
+        # Extract RLU values
         rlu_values = defaultdict(list)
-        for episode in self.rlu_dataset:
-            for key in episode.keys():
-                if key == 'steps':
-                    # Handle steps variant dataset
-                    for step in episode[key]:
-                        print(step.keys())
-                        for step_key in step.keys():      
-                            if isinstance(step[step_key], dict):
-                                for k, v in step[step_key].items():
-                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                rlu_values[f'steps/{step_key}'].append(step[step_key])
-                else:
-                    rlu_values[key].append(episode[key])
-            break
-            
+        for raw_record in self.rlu_dataset:
 
+            example = tf.train.Example()
+            example.ParseFromString(raw_record.numpy())
+
+            for key, feature in example.features.feature.items():
+                if feature.HasField('int64_list'):
+                    val = tf.convert_to_tensor(feature.int64_list.value)
+                elif feature.HasField('float_list'):
+                    val = tf.convert_to_tensor(feature.float_list.value)
+                elif feature.HasField('bytes_list'):
+                    val = []
+                    for step in feature.bytes_list.value:
+                        try:
+                            val.append(tf.image.decode_jpeg(step, channels=3))
+                        except:
+                            val.append(tf.io.decode_raw(step, tf.uint8))
+                    val = tf.convert_to_tensor(val)
+                else:
+                    print(f"Unsupported feature type: {key}")
             
-        #print(rlu_values)
-        
+            rlu_values[key].append(val)
+
+        # Extract TFDS values  
         tfds_values = defaultdict(list)
-        for episode in self.tfds_dataset_ep_1:
-            for key in episode.keys():
-                if key == 'steps':
-                    for step_number in episode[key]:
-                        for step_key in episode[key][step_number].keys():
-                            if isinstance(episode[key][step_number][step_key], dict):
-                                for k, v in episode[key][step_number][step_key].items():
-                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                tfds_values[f'steps/{step_key}'].append(episode[key][step_number][step_key])
-                else:
-                    tfds_values[key].append(episode[key])
-            
-
-        #print(tfds_values)
+        for ele in self.tfds_dataset:
+            for key, value in ele.items():
+                tfds_values[key].append(value)
 
         test_values_match(rlu_values, tfds_values)
-
-        #Compare values of last episode
-
-        for episode in self.rlu_dataset:
-            pass
-        rlu_ele = episode
-        tfds_ele = next(iter(self.tfds_dataset_ep_40))
-        
-        rlu_values = defaultdict(list)
-        for key in rlu_ele.keys():
-            if key == 'steps':
-                # Handle steps variant dataset
-                for step in rlu_ele[key]:
-                        print(step.keys())
-                        for step_key in step.keys():      
-                            if isinstance(step[step_key], dict):
-                                for k, v in step[step_key].items():
-                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                rlu_values[f'steps/{step_key}'].append(step[step_key])
-                else:
-                    rlu_values[key].append(rlu_ele[key])
-            break
-        
-        tfds_values = defaultdict(list)
-
-        for key in tfds_ele.keys():
-            if key == 'steps':
-                for step_number in tfds_ele[key]:
-                    for step_key in tfds_ele[key][step_number].keys():
-                        if isinstance(tfds_ele[key][step_number][step_key], dict):
-                            for k, v in tfds_ele[key][step_number][step_key].items():
-                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
-            else:
-                tfds_values[key].append(tfds_ele[key])
-
-        test_values_match(rlu_values, tfds_values)
-
-        #Compare values of 17th episode
-        count=1
-        for episode in self.rlu_dataset:
-            if count == 17:
-                rlu_ele = episode
-                break
-            count += 1
-
-        tfds_ele = next(iter(self.tfds_dataset_ep_17))
-        
-        rlu_values = defaultdict(list)
-        for key in rlu_ele.keys():
-            if key == 'steps':
-                # Handle steps variant dataset
-                for step in rlu_ele[key]:
-                        print(step.keys())
-                        for step_key in step.keys():      
-                            if isinstance(step[step_key], dict):
-                                for k, v in step[step_key].items():
-                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                rlu_values[f'steps/{step_key}'].append(step[step_key])
-                else:
-                    rlu_values[key].append(rlu_ele[key])
-            break
-
-        tfds_values = defaultdict(list)
-
-        for key in tfds_ele.keys():
-            if key == 'steps':
-                for step_number in tfds_ele[key]:
-                    for step_key in tfds_ele[key][step_number].keys():
-                        if isinstance(tfds_ele[key][step_number][step_key], dict):
-                            for k, v in tfds_ele[key][step_number][step_key].items():
-                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
-            else:
-                tfds_values[key].append(tfds_ele[key])
-
-        test_values_match(rlu_values, tfds_values)
-
         print(f'Time taken for data values test: {time.time() - start_time} seconds')
 
     def test_data_types_match(self):
         """Test that data types are preserved"""
         start_time = time.time()
-        
+
         # Get first elements
         rlu_first = next(iter(self.rlu_dataset))
-        tfds_first = self.tfds_dataset_ep_1
+        tfds_first = next(iter(self.tfds_dataset))
 
-        # Get datatypes of all features of origin dataset
-        rlu_datatypes = {}
-        for episode in self.rlu_dataset:
-            for key in episode.keys():
-                if key == 'steps':
-                    # Handle steps variant dataset
-                    for step in episode[key]:
-                        print(step.keys())
-                        for step_key in step.keys():      
-
-                            if isinstance(step[step_key], dict):
-                                for k, v in step[step_key].items():
-                                    rlu_datatypes[f'steps/{step_key}/{k}'] = v.dtype
-                            else:
-                                rlu_datatypes[f'steps/{step_key}'] = step[step_key].dtype
-                        
-                        break
-                else:
-                    
-                    rlu_datatypes[key] = episode[key].dtype
-            break
-
-        print(rlu_datatypes)
-
-        # Get datatypes of all features of translated dataset
-        tfds_datatypes = {}
-        for episode in self.tfds_dataset_ep_1:
-            for key in episode.keys():
-                if key == 'steps':
-                    for step_number in episode[key]:
-                        for step_key in episode[key][step_number].keys():
-                            if isinstance(episode[key][step_number][step_key], dict):
-                                for k, v in episode[key][step_number][step_key].items():
-                                    tfds_datatypes[f'steps/{step_key}/{k}'] = v.dtype
-                            else:
-                                tfds_datatypes[f'steps/{step_key}'] = episode[key][step_number][step_key].dtype
-                        break
-                    
-                else:
-                    tfds_datatypes[key] = episode[key].dtype
-            break
-
-        print(tfds_datatypes)
-
-        self.assertEqual(rlu_datatypes, tfds_datatypes)
+        example = tf.train.Example()
+        example.ParseFromString(rlu_first.numpy())
         
+        rlu_dtypes = {}
+        for key, feature in example.features.feature.items():
+            if feature.HasField('int64_list'):
+                rlu_dtypes[key] = tf.int64
+            elif feature.HasField('float_list'):
+                rlu_dtypes[key] = tf.float32
+            elif feature.HasField('bytes_list'):
+                rlu_dtypes[key] = tf.uint8
+            else:
+                rlu_dtypes[key] = None
+
+        # Get datatypes from translated dataset
+        tfds_dtypes = {}
+        for key, value in tfds_first.items():
+            if value.dtype == tf.int32:
+                tfds_dtypes[key] = tf.int64
+            else:
+                tfds_dtypes[key] = value.dtype
+        
+        print(rlu_dtypes)
+        print(tfds_dtypes)
+        self.assertEqual(rlu_dtypes, tfds_dtypes)
         print(f'Time taken for data types test: {time.time() - start_time} seconds')
 
 if __name__ == '__main__':
     unittest.main()
+

--- a/src/control_translation/tests/testrlutfds.py
+++ b/src/control_translation/tests/testrlutfds.py
@@ -73,8 +73,6 @@ class TestRLUToTFDS(unittest.TestCase):
             for key in episode.keys():
                 if key == 'steps':
                     for step_number in episode[key]:
-                        #print('\nCHECK')
-                        #print(episode[key][step_number].keys())
                         for step_key in episode[key][step_number].keys():
                             tfds_features.add(f'steps/{step_key}')
                         break
@@ -179,21 +177,21 @@ class TestRLUToTFDS(unittest.TestCase):
                                     rlu_values[f'steps/{step_key}/{k}'].append(v)
                             else:
                                 rlu_values[f'steps/{step_key}'].append(step[step_key])
-                else:
-                    rlu_values[key].append(rlu_ele[key])
-            break
+            else:
+                rlu_values[key].append(rlu_ele[key])
         
         tfds_values = defaultdict(list)
 
         for key in tfds_ele.keys():
             if key == 'steps':
-                for step_number in tfds_ele[key]:
+                step_numbers = sorted(tfds_ele[key].keys(), key=lambda x: int(x))
+                for step_number in step_numbers:
                     for step_key in tfds_ele[key][step_number].keys():
                         if isinstance(tfds_ele[key][step_number][step_key], dict):
                             for k, v in tfds_ele[key][step_number][step_key].items():
                                     tfds_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
+                        else:
+                            tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
             else:
                 tfds_values[key].append(tfds_ele[key])
 
@@ -221,21 +219,21 @@ class TestRLUToTFDS(unittest.TestCase):
                                     rlu_values[f'steps/{step_key}/{k}'].append(v)
                             else:
                                 rlu_values[f'steps/{step_key}'].append(step[step_key])
-                else:
-                    rlu_values[key].append(rlu_ele[key])
-            break
+            else:
+                rlu_values[key].append(rlu_ele[key])
 
         tfds_values = defaultdict(list)
 
         for key in tfds_ele.keys():
             if key == 'steps':
-                for step_number in tfds_ele[key]:
+                step_numbers = sorted(tfds_ele[key].keys(), key=lambda x: int(x))
+                for step_number in step_numbers:
                     for step_key in tfds_ele[key][step_number].keys():
                         if isinstance(tfds_ele[key][step_number][step_key], dict):
                             for k, v in tfds_ele[key][step_number][step_key].items():
                                     tfds_values[f'steps/{step_key}/{k}'].append(v)
-                            else:
-                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
+                        else:
+                            tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
             else:
                 tfds_values[key].append(tfds_ele[key])
 

--- a/src/control_translation/tests/testrlutfds.py
+++ b/src/control_translation/tests/testrlutfds.py
@@ -1,0 +1,303 @@
+from collections import defaultdict
+import random
+import unittest
+import tensorflow as tf
+import tensorflow_datasets as tfds
+import numpy as np
+import os
+import time
+
+class TestRLUToTFDS(unittest.TestCase):
+    
+    def setUp(self):
+        start_time = time.time()
+        # Load a sample RLU dataset
+        self.rlu_dataset = tfds.load(
+            'rlu_control_suite/cartpole_swingup',
+            split='train',
+            data_dir='../..',
+            download=False
+        )
+        print(f'Time taken for RLU dataset load: {time.time() - start_time} seconds')
+        
+        # Load first 3 episodes of translated TFDS dataset
+        start_time = time.time()
+        self.tfds_dataset_ep_1 = tf.data.Dataset.load('../dm_control_suite_rlu_tfds_translated/rlu_control_suite/cartpole_swingup/translated_episode_1')
+        self.tfds_dataset_ep_40 = tf.data.Dataset.load('../dm_control_suite_rlu_tfds_translated/rlu_control_suite/cartpole_swingup/translated_episode_40')
+        self.tfds_dataset_ep_17 = tf.data.Dataset.load('../dm_control_suite_rlu_tfds_translated/rlu_control_suite/cartpole_swingup/translated_episode_17')
+        print(f'Time taken for translated dataset load: {time.time() - start_time} seconds')
+
+    def test_dataset_sizes_match(self):
+        """Test that datasets have same number of examples"""
+        start_time = time.time()
+        rlu_lens = 0
+        tfds_lens = 0
+        
+        # Get lengths from RLU dataset
+        for episode in self.rlu_dataset:
+            rlu_lens += 1
+             
+        # Count the number of translated episode files
+        translated_dir = '../dm_control_suite_rlu_tfds_translated/rlu_control_suite/cartpole_swingup/'
+        tfds_lens = len([f for f in os.listdir(translated_dir) if f.startswith('translated_')])
+
+        self.assertGreater(rlu_lens, 0)
+        self.assertGreater(tfds_lens, 0)
+        self.assertEqual(rlu_lens, tfds_lens)
+        print(f'Time taken for dataset size test: {time.time() - start_time} seconds')
+
+    def test_feature_names_match(self):
+        """Test that feature names are preserved"""
+        start_time = time.time()
+        
+        # Get RLU feature names
+        rlu_features = set()
+        for episode in self.rlu_dataset:
+            for key in episode.keys():
+                if key == 'steps':
+                    # Handle steps variant dataset
+                    for step in episode[key]:
+                        #print(step.keys())
+                        for step_key in step.keys():      
+
+                            rlu_features.add(f'steps/{step_key}')
+                        
+                        break
+                else:
+                    rlu_features.add(key)
+            break
+
+        # Get translated feature names
+        tfds_features = set()
+        for episode in self.tfds_dataset_ep_1:
+            for key in episode.keys():
+                if key == 'steps':
+                    for step_number in episode[key]:
+                        #print('\nCHECK')
+                        #print(episode[key][step_number].keys())
+                        for step_key in episode[key][step_number].keys():
+                            tfds_features.add(f'steps/{step_key}')
+                        break
+                    
+                else:
+                    tfds_features.add(key)
+            break
+
+        self.assertEqual(rlu_features, tfds_features)
+        print(f'Time taken for feature names test: {time.time() - start_time} seconds')
+
+    def test_data_values_match(self):
+
+        def test_values_match(rlu_values, tfds_values):
+        # Compare values between RLU and TFDS datasets
+            for key in rlu_values.keys():
+                self.assertIn(key, tfds_values, f"Key {key} missing from translated dataset")
+                
+                rlu_arr = rlu_values[key]
+                tfds_arr = tfds_values[key]
+                
+                self.assertEqual(len(rlu_arr), len(tfds_arr), 
+                            f"Length mismatch for {key}: RLU={len(rlu_arr)}, TFDS={len(tfds_arr)}")
+                
+                for i, (rlu_val, tfds_val) in enumerate(zip(rlu_arr, tfds_arr)):
+                    if isinstance(rlu_val, (np.ndarray, tf.Tensor)):
+                        np.testing.assert_array_equal(
+                            rlu_val.numpy() if isinstance(rlu_val, tf.Tensor) else rlu_val,
+                            tfds_val.numpy() if isinstance(tfds_val, tf.Tensor) else tfds_val,
+                            err_msg=f"Value mismatch for {key}[{i}]"
+                        )
+                    else:
+                        self.assertEqual(rlu_val, tfds_val,
+                                    f"Value mismatch for {key}[{i}]: RLU={rlu_val}, TFDS={tfds_val}")
+        
+        start_time = time.time()
+        
+        # Compare first episode
+
+        tfds_ele = next(iter(self.tfds_dataset_ep_1))
+        rlu_ele = self.rlu_dataset
+
+        #Compare values of first episode
+        rlu_values = defaultdict(list)
+        for episode in self.rlu_dataset:
+            for key in episode.keys():
+                if key == 'steps':
+                    # Handle steps variant dataset
+                    for step in episode[key]:
+                        #print(step.keys())
+                        for step_key in step.keys():      
+                            if isinstance(step[step_key], dict):
+                                for k, v in step[step_key].items():
+                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                rlu_values[f'steps/{step_key}'].append(step[step_key])
+                else:
+                    rlu_values[key].append(episode[key])
+            break
+            
+
+            
+        #print(rlu_values)
+        
+        tfds_values = defaultdict(list)
+        for episode in self.tfds_dataset_ep_1:
+            for key in episode.keys():
+                if key == 'steps':
+                    step_numbers = sorted(episode[key].keys(), key=lambda x: int(x))
+                    for step_number in step_numbers:
+                        # Sort step numbers by converting to integers
+                        
+                        for step_key in episode[key][step_number].keys():
+                            if isinstance(episode[key][step_number][step_key], dict):
+                                for k, v in episode[key][step_number][step_key].items():
+                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                tfds_values[f'steps/{step_key}'].append(episode[key][step_number][step_key])
+                else:
+                    tfds_values[key].append(episode[key])
+            
+
+        #print(tfds_values)
+
+        test_values_match(rlu_values, tfds_values)
+
+        #Compare values of last episode
+
+        for episode in self.rlu_dataset:
+            pass
+        rlu_ele = episode
+        tfds_ele = next(iter(self.tfds_dataset_ep_40))
+        
+        rlu_values = defaultdict(list)
+        for key in rlu_ele.keys():
+            if key == 'steps':
+                # Handle steps variant dataset
+                for step in rlu_ele[key]:
+                        for step_key in step.keys():      
+                            if isinstance(step[step_key], dict):
+                                for k, v in step[step_key].items():
+                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                rlu_values[f'steps/{step_key}'].append(step[step_key])
+                else:
+                    rlu_values[key].append(rlu_ele[key])
+            break
+        
+        tfds_values = defaultdict(list)
+
+        for key in tfds_ele.keys():
+            if key == 'steps':
+                for step_number in tfds_ele[key]:
+                    for step_key in tfds_ele[key][step_number].keys():
+                        if isinstance(tfds_ele[key][step_number][step_key], dict):
+                            for k, v in tfds_ele[key][step_number][step_key].items():
+                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
+            else:
+                tfds_values[key].append(tfds_ele[key])
+
+        test_values_match(rlu_values, tfds_values)
+
+        #Compare values of 17th episode
+        count=1
+        for episode in self.rlu_dataset:
+            if count == 17:
+                rlu_ele = episode
+                break
+            count += 1
+
+        tfds_ele = next(iter(self.tfds_dataset_ep_17))
+        
+        rlu_values = defaultdict(list)
+        for key in rlu_ele.keys():
+            if key == 'steps':
+                # Handle steps variant dataset
+                for step in rlu_ele[key]:
+                        #print(step.keys())
+                        for step_key in step.keys():      
+                            if isinstance(step[step_key], dict):
+                                for k, v in step[step_key].items():
+                                    rlu_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                rlu_values[f'steps/{step_key}'].append(step[step_key])
+                else:
+                    rlu_values[key].append(rlu_ele[key])
+            break
+
+        tfds_values = defaultdict(list)
+
+        for key in tfds_ele.keys():
+            if key == 'steps':
+                for step_number in tfds_ele[key]:
+                    for step_key in tfds_ele[key][step_number].keys():
+                        if isinstance(tfds_ele[key][step_number][step_key], dict):
+                            for k, v in tfds_ele[key][step_number][step_key].items():
+                                    tfds_values[f'steps/{step_key}/{k}'].append(v)
+                            else:
+                                tfds_values[f'steps/{step_key}'].append(tfds_ele[key][step_number][step_key])
+            else:
+                tfds_values[key].append(tfds_ele[key])
+
+        test_values_match(rlu_values, tfds_values)
+
+        print(f'Time taken for data values test: {time.time() - start_time} seconds')
+
+    def test_data_types_match(self):
+        """Test that data types are preserved"""
+        start_time = time.time()
+        
+        # Get first elements
+        rlu_first = next(iter(self.rlu_dataset))
+        tfds_first = self.tfds_dataset_ep_1
+
+        # Get datatypes of all features of origin dataset
+        rlu_datatypes = {}
+        for episode in self.rlu_dataset:
+            for key in episode.keys():
+                if key == 'steps':
+                    # Handle steps variant dataset
+                    for step in episode[key]:
+                        #print(step.keys())
+                        for step_key in step.keys():      
+
+                            if isinstance(step[step_key], dict):
+                                for k, v in step[step_key].items():
+                                    rlu_datatypes[f'steps/{step_key}/{k}'] = v.dtype
+                            else:
+                                rlu_datatypes[f'steps/{step_key}'] = step[step_key].dtype
+                        
+                        break
+                else:
+                    
+                    rlu_datatypes[key] = episode[key].dtype
+            break
+
+        #print(rlu_datatypes)
+
+        # Get datatypes of all features of translated dataset
+        tfds_datatypes = {}
+        for episode in self.tfds_dataset_ep_1:
+            for key in episode.keys():
+                if key == 'steps':
+                    for step_number in episode[key]:
+                        for step_key in episode[key][step_number].keys():
+                            if isinstance(episode[key][step_number][step_key], dict):
+                                for k, v in episode[key][step_number][step_key].items():
+                                    tfds_datatypes[f'steps/{step_key}/{k}'] = v.dtype
+                            else:
+                                tfds_datatypes[f'steps/{step_key}'] = episode[key][step_number][step_key].dtype
+                        break
+                    
+                else:
+                    tfds_datatypes[key] = episode[key].dtype
+            break
+
+        #print(tfds_datatypes)
+
+        self.assertEqual(rlu_datatypes, tfds_datatypes)
+        
+        print(f'Time taken for data types test: {time.time() - start_time} seconds')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/control_translation/translatemultiple.py
+++ b/src/control_translation/translatemultiple.py
@@ -36,13 +36,13 @@ def translate_shards(dataset_name, dataset_path, hf_test_data, limit_schema, out
                 for f in filenames:
                     if not f.endswith('.json'):
                         all_files.append(os.path.join(dirpath, f))
-        print(all_files)
+        #print(all_files)
         for file in all_files:
             translated_ds = rlu(file, limit_schema)
             mod_file_path = file.replace('../', '')
             path_to_translated = os.path.join(dataset_name+'_translated/', mod_file_path)
             tf.data.Dataset.save(translated_ds, os.path.join(output_dir, path_to_translated),shard_func=custom_shard_func)
-            print(f'Translated and stored file in {output_dir}')
+        print(f'Translated and stored file in {output_dir}')
 
     elif dataset_name=='baby_ai' or dataset_name=='ale_atari' or dataset_name=='mujoco' or dataset_name=='meta_world':
 

--- a/src/control_translation/translatemultiple.py
+++ b/src/control_translation/translatemultiple.py
@@ -18,15 +18,31 @@ def build_arg_parser() -> ArgumentParser:
 
 def translate_shards(dataset_name, dataset_path, hf_test_data, limit_schema, output_dir):
     
-    if dataset_name=='dm_lab_rlu' or dataset_name=='dm_control_suite_rlu':
+    if dataset_name=='dm_lab_rlu_tfds' or dataset_name=='dm_control_suite_rlu_tfds':
         
         dir_path = dataset_path
         translated_ds = rlu_tfds(dir_path, limit_schema, output_dir, dataset_name)
-        #mod_file_path = dir_path.replace('../', '')
-        #path_to_translated = os.path.join(dataset_name+'_translated/', mod_file_path)
-        #print(path_to_translated)
-        #tf.data.Dataset.save(translated_ds, os.path.join(output_dir, path_to_translated),shard_func=custom_shard_func)
-        print(f'Translated and stored file {output_dir}')
+        print(f'Translated and stored file in {output_dir}')
+    
+    elif dataset_name=='dm_lab_rlu' or dataset_name=='dm_control_suite_rlu':
+        
+        dir_path = dataset_path
+        # Get all files in the leaf level of dataset_path
+        all_files = []
+        for dirpath, dirnames, filenames in os.walk(dataset_path):
+            # If this is a leaf directory (no subdirectories)
+            if not dirnames:
+                # Add all non-JSON files
+                for f in filenames:
+                    if not f.endswith('.json'):
+                        all_files.append(os.path.join(dirpath, f))
+        print(all_files)
+        for file in all_files:
+            translated_ds = rlu(file, limit_schema)
+            mod_file_path = file.replace('../', '')
+            path_to_translated = os.path.join(dataset_name+'_translated/', mod_file_path)
+            tf.data.Dataset.save(translated_ds, os.path.join(output_dir, path_to_translated),shard_func=custom_shard_func)
+            print(f'Translated and stored file in {output_dir}')
 
     elif dataset_name=='baby_ai' or dataset_name=='ale_atari' or dataset_name=='mujoco' or dataset_name=='meta_world':
 


### PR DESCRIPTION
src/centralized_downloader.py:
- Remove DM Lab from TFDS download method as it doesn't work
- Add calls to 2 separate RLU download modules based on preferred method

src/control_translation/centralized_translation.py:
- Add module to translate RL Unplugged datasets downloaded using the GCP download method
- Fix handling of images during translation of RL Unplugged datasets downloaded using the GCP download method

src/control_translation/tests/testrlu.py:
- Modify this script to be translation test for RL Unplugged datasets downloaded using the GCP method

src/control_translation/tests/testrlutfds.py:
- Translation test script for RL Unplugged datasets downloaded using TFDS

src/control_translation/translatemultiple.py:
- Add separate modules and input file ingestions for RL Unplugged TFDS and GCP download methods
