### PR TITLE
Genesis batch processing

### DIFF
--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -1,30 +1,40 @@
+from dataclasses import dataclass
+
+import tensorflow as tf
 from src.modules.modality_modules.vlm_module import VLMModule
 from src.data_utils.openx_dataloader import get_openx_dataloader
 from definitions.prompt import format_instruction_prompt
 from definitions.openx import DESCRIPTIONS, ACTION_SPACES, ACTION_EXCLUSIVENESS, ADDITIONAL_INSTRUCTIONS
 from typing import Any, Union
 from glob import glob
+from pathlib import Path
 
 import numpy as np
 import json
 import string
 import time
 import os
+import warnings
+
 
 class OpenXModule:
     def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, batch_size: int, k_shots: int) -> None:
         self.disk_root_dir = disk_root_dir
-        self.datasets = list(DESCRIPTIONS.keys())
-
+        self.datasets = []
+        for dataset in list(DESCRIPTIONS.keys()):
+            tfds_shards = self._find_shards(dataset)
+            if len(tfds_shards) != 0:
+                self.datasets.append(dataset)
+                
         self.modality_module = None
         if modality == 'vlm':
-            self.modality_module = VLMModule(source, model)
+            self.modality_module = VLMModule(source, model, max_concurrent_prompts=batch_size)
         assert self.modality_module is not None, "The modality module has not been set correcly. Check required."
 
         self.batch_size = batch_size
         self.k_shots = k_shots
         self.action_stats_opxmodule = None
-
+        
     # Main evaluation function.
     def run_eval(self) -> None:
         # Since OpenX consists of multiple datasets, a modality module should be initialized per every evaluation step for each dataset.
@@ -58,6 +68,42 @@ class OpenXModule:
                 json.dump(existing_results, f, indent=4, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
             self.action_stats_opxmodule = None
 
+    def _process_episode(self, episode):
+        text_observation = []
+        image_observation = []
+        etc_observations = {}
+        concatenated_action_float = []
+        reward = []
+        is_last = []
+
+        for timestep in episode:
+            text_observation.append(timestep['text_observation'])
+            timestep.pop('text_observation')
+            image_observation.append(timestep['image_observation'])
+            timestep.pop('image_observation')
+            concatenated_action_float.append(timestep['action'])
+            timestep.pop('action')
+            reward.append(timestep['reward'])
+            timestep.pop('reward')
+            is_last.append(timestep['is_last'])
+            timestep.pop('is_last')
+
+            for key, value in timestep.items():
+                if key not in etc_observations:
+                    etc_observations[key] = []
+                etc_observations[key].append(value)
+
+        result = {
+            'text_observation': text_observation,
+            'image_observation': image_observation,
+            'action': concatenated_action_float,
+            'reward': reward,
+            'is_last': is_last
+        }
+        result.update(etc_observations)
+
+        return result
+    
     # Evaluation of one dataset.
     def _run_eval_dataset(self, dataset: str) -> dict[str, Union[list, float]]:
         result = {}
@@ -82,17 +128,18 @@ class OpenXModule:
                 # Action stats need to be retrieved only once for each dataset, after they have been populated.
                 if self.action_stats_opxmodule is None:
                     self.action_stats_opxmodule = dataloader_obj._get_action_stats()  
-                batch_size = len(batch['text_observation'])
                 #episode_mses = [[] for b in range(batch_size)]
                 #success_counts = [0 for b in range(batch_size)]
 
                 # Consuming the batch until all timesteps in the batch.
                 for cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts in self._process_batch(batch, dataset):
+                       
+                    
                     outputs = self.modality_module.infer_step(cur_inputs, k_shots_examples, instructions, output_types)  # (B)
-
+                    
                     # Any invalid output 'None' should be initialized into a random action.
                     outputs = [self._validate_text_output(output, shape=labels[o].shape) for o, output in enumerate(outputs)]
-
+                        
                     if isinstance(outputs[0][0], float)==False:
                         outputs = [[float(item) for item in sublist] for sublist in outputs]
 
@@ -178,6 +225,8 @@ class OpenXModule:
 
     # Forming the batch.
     def _process_batch(self, batch: dict[str, list[Any]], dataset: str):
+        # TODO: this probably doesnt make sense anymore since we're only getting 1 episode, 
+        #   and batching 1 episode vertically just gives us 1 timestep every time
         # Getting the maxmimum length of episodes.
         text_obs = batch['text_observation']
         batch_size = len(text_obs)
@@ -219,9 +268,8 @@ class OpenXModule:
                             cur_inputs[-1].append((key, value[b][t]))
 
                     cur_inputs[-1].append(('text_observation', text_obs[b][t]))
-
             yield cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts
-
+            
     # Generating the instruction text for VLMModule.
     def _get_vlm_instruction(self, dataset: str, env_name: str):
         assert dataset in DESCRIPTIONS, f"The dataset {dataset} is not included in the OpenX group."
@@ -279,3 +327,230 @@ class OpenXModule:
             output = np.random.random(size=shape)
         
         return np.array(output)
+
+@dataclass
+class BatchInfo:
+    dataset_name: str
+    batch_num: int
+    batch_id: str
+    output_types: list[str]
+    token_count: int
+    is_lasts: list[int]
+    labels: list
+    num_inputs: int
+    save_root: str
+    
+    def save_to_file(self) -> str:
+        save_dir = f"{self.save_root}/batch_info/{self.dataset_name}_size_{self.num_inputs}"
+        # Create folders if they dont exist        
+        Path(save_dir).mkdir(parents=True, exist_ok=True)
+        
+        file_name = f"batch_{self.batch_num}.npz"
+        run = 0
+        while Path(f'{save_dir}/run_{run}/{file_name}').exists():
+            run += 1
+        Path(f'{save_dir}/run_{run}').mkdir()
+                    
+        np.savez(f'{save_dir}/run_{run}/{file_name}', 
+                 dataset_name=self.dataset_name, batch_num=self.batch_num, batch_id=self.batch_id, 
+                 output_types=self.output_types, token_count=self.token_count, is_lasts=self.is_lasts, 
+                 labels=self.labels, num_inputs=self.num_inputs)
+                
+        return Path(f'{save_dir}/run_{run}/{file_name}').absolute()
+ 
+class OpenXBatchModule(OpenXModule):
+    def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, batch_size: int, k_shots: int):
+        super().__init__(disk_root_dir, modality, source, model, batch_size, k_shots)
+        self.batch_list = {ds : [] for ds in self.datasets}
+        
+    def _send_batch_job(self, batch, dataset_name, batch_num):
+        cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts = self._process_batch(batch, dataset_name)
+        num_inputs = len(cur_inputs)
+        batch_id, token_count = self.modality_module.send_batch_job(cur_inputs, [], instructions)
+        
+        is_lasts = [int(is_last) for is_last in is_lasts]
+        labels = [label.numpy() for label in labels]
+
+        batch_job = BatchInfo(dataset_name, batch_num, batch_id, output_types, token_count, is_lasts, labels, num_inputs, self.disk_root_dir)
+        fp = batch_job.save_to_file()
+        self.batch_list[dataset_name].append(fp)
+        
+    def _send_batch_jobs_for_dataset(self, dataset):
+        tfds_shards = self._find_shards(dataset)
+        if len(tfds_shards) == 0:
+            return {}
+
+        # Creating the dataloader.
+        dataloader_obj, dataloader = get_openx_dataloader(tfds_shards, batch_size=self.batch_size)
+
+        for i, batch in enumerate(dataloader):
+            # Action stats need to be retrieved only once for each dataset, after they have been populated.
+            if self.action_stats_opxmodule is None:
+                self.action_stats_opxmodule = dataloader_obj._get_action_stats()  
+            self._send_batch_job(batch, dataset, i)
+        return self.batch_list[dataset]
+        
+    def send_batch_jobs_for_all_datasets(self):
+        for dataset in self.datasets:
+            self._send_batch_jobs_for_dataset(dataset)
+            self.action_stats_opxmodule = None
+        return self.batch_list  
+        
+    def _run_eval_dataset(self, dataset_batch_info_folder):
+        result = {}
+        
+        #avg_mse_list = []
+        total_dataset_mse = 0.0
+        #episode_count = 0
+        action_success = []
+        timestep_mse = []
+        start_time = time.time()
+        
+        paths = Path(dataset_batch_info_folder).iterdir()
+        for fp in paths:
+            try:
+                if Path(fp).exists():
+                    batch_info = np.load(fp, allow_pickle=True)  
+                else:
+                    warnings.warn(f'Could not find file at path {fp}. Skipping...')
+                    continue    
+            except:
+                warnings.warn(f'Could not open file at path {fp}. Skipping...')
+                continue
+                    
+            output_types = list(batch_info['output_types'])
+            ds = batch_info['dataset_name'].item()
+            batch_num = batch_info['batch_num'].item()
+            batch_id = batch_info['batch_id'].item()
+            labels = [tf.convert_to_tensor(label) for label in batch_info['labels']]
+            num_inputs = batch_info['num_inputs'].item()
+            is_lasts = [bool(is_last) for is_last in batch_info['is_lasts']]
+            
+            status = self.modality_module.get_batch_job_status(batch_id)
+            if status == 'completed':
+                outputs = self.modality_module.retrieve_batch_results(batch_id, output_types)
+            else:
+                warnings.warn(f'Batch not completed for batch {ds} batch num {batch_num} '
+                              f'with batch id {batch_id}. Status: {status}. Skipping...')
+                continue
+            
+            outputs = [self._validate_text_output(output, shape=labels[o].shape) for o, output in enumerate(outputs)]
+                
+            if isinstance(outputs[0][0], float)==False:
+                outputs = [[float(item) for item in sublist] for sublist in outputs]
+
+            # This only works for continuous vector actions. (Okay for OpenX)
+            mses = np.mean((np.array(labels) - np.array(outputs)) ** 2, axis=-1)
+            assert len(mses) == num_inputs, "The calculated MSEs are not matched with the processed inputs."
+
+            for i in range(num_inputs):
+                #episode_mses[idx].append(mses[i])
+                timestep_mse.append(mses[i])
+                # If any episodes are the last, recording the success rate.
+                if is_lasts[i]:
+                    #print(outputs[i])
+                    #print(labels[i])
+                    if np.array_equal(np.array(outputs[i]), np.array(labels[i])):
+                        #success_counts[idx] += 1
+                        action_success.append(1)
+                    else:
+                        action_success.append(0)
+        action_success_rate = (sum(action_success) / len(action_success)) * 100
+        total_dataset_mse = sum(timestep_mse)
+        print(f"\nTotal MSE across {len(timestep_mse)} timesteps: {total_dataset_mse:.4f}")
+        num_timesteps = len(timestep_mse)
+        avg_dataset_mse = total_dataset_mse / num_timesteps
+
+        # Calculate average AMSE over all episodes
+        #avg_dataset_amse = total_dataset_amse / episode_count
+        
+        # Calculate min-max normalized AMSE
+        min_mse = min(timestep_mse)
+        max_mse = max(timestep_mse)
+        normalized_mse = (timestep_mse - min_mse) / (max_mse - min_mse) if max_mse != min_mse else 0
+        normalized_amse = sum(normalized_mse) / len(normalized_mse)
+
+        end_time = time.time()
+        eval_time = end_time - start_time
+
+        '''result['action_success_rate'] = (sum(total_success_counts) / len(total_success_counts)) * 100
+        result['avg_mse_list'] = avg_mse_list
+        result['episode_count'] = episode_count
+        result['total_dataset_amse'] = total_dataset_amse
+
+        # Calculating average AMSE over all episodes
+        avg_dataset_amse = total_dataset_amse / episode_count
+        
+        # Calculating min-max normalized AMSE
+        min_amse = min(avg_mse_list)
+        max_amse = max(avg_mse_list)
+        result['normalized_amse'] = (avg_dataset_amse - min_amse) / (max_amse - min_amse) if max_amse != min_amse else 0
+        result['eval_time'] = eval_time'''
+
+        result['action_success_rate'] = action_success_rate
+        result['total_dataset_amse'] = total_dataset_mse
+        result['num_timesteps'] = num_timesteps
+        result['avg_dataset_amse'] = avg_dataset_mse
+        result['normalized_amse'] = normalized_amse
+        result['eval_time'] = eval_time
+        
+        return result
+    
+    # Forming the batch.
+    def _process_batch(self, batch: dict[str, list[Any]], dataset: str):
+        # Getting the maxmimum length of episodes.
+        text_obs = batch['text_observation']
+        
+        batch_size = len(text_obs)
+        max_timesteps = 0
+        for b in range(batch_size):
+            max_timesteps = max(max_timesteps, len(text_obs[b]))
+        
+        for b in range(batch_size):
+            samples = 0
+            cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts = [], [], [], [], [], [], []
+            for t in range(max_timesteps):
+                if t < len(text_obs[b]):
+                    # This batch is consumed.
+                    idxs.append(samples)
+                    cur_inputs.append([])
+
+                    # First, setting the instructions and output types.
+                    env_name = text_obs[b][t].strip().strip(string.punctuation).lower()
+                    instruction = self._get_vlm_instruction(dataset, env_name)
+                    instructions.append(instruction)
+
+                    output_type = self._get_output_type(dataset, env_name)
+                    output_types.append(output_type)
+
+                    labels.append(batch['action'][b][t])
+                    is_lasts.append(batch['is_last'][b][t])
+
+                    if 'image_observation' in batch and batch['image_observation'][b][t] is not None:
+                        image_obs = batch['image_observation'][b][t]
+                        if len(image_obs.shape) == 4:
+                            image_obs = [('image_observation', image) for image in image_obs]
+                            cur_inputs[-1] += image_obs
+                        else:
+                            cur_inputs[-1].append(('image_observation', image_obs))
+
+                    # Processing additional observations.
+                    for key, value in batch.items():
+                        if key != 'action' and key != 'reward' and key != 'is_last' and key != 'image_observation' and key != 'text_observation' and value[b][t] is not None:
+                            cur_inputs[-1].append((key, value[b][t]))
+
+                    cur_inputs[-1].append(('text_observation', text_obs[b][t]))
+                    
+                    samples += 1
+                    
+                if samples == self.batch_size:
+                    yield cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts
+                    samples = 0
+                    cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts = [], [], [], [], [], [], []
+            
+            # If there are any remaining samples, yield them
+            if samples > 0:
+                yield cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts        
+                samples = 0
+                cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts = [], [], [], [], [], [], []
+    

--- a/src/modules/modality_modules/vlm_module.py
+++ b/src/modules/modality_modules/vlm_module.py
@@ -21,7 +21,7 @@ class VLMModule:
                    k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=[],
                    instructions: list[str]=[],
                    output_types: list[type]=[]
-                ) -> list[str]:
+                   ) -> list[str]:
         processed_cur_inputs, processed_k_shots_examples = self._process_inputs(cur_inputs, k_shots_examples)
 
         outputs = []
@@ -46,14 +46,49 @@ class VLMModule:
                 self.source_module.clear_history()
 
         return outputs
+    
+    def batch_infer_step(self, 
+                         cur_inputs: list[list[tuple[str, Any]]],
+                         k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=None,
+                         instructions: Union[str, list[str]]=None,
+                         output_types: Union[type, list[type]]=None
+                         ) -> list[str]:
+        if k_shots_examples is None:
+            k_shots_examples = []
+        if instructions is None:
+            instructions = []
         
+        output_type = str
+        if output_types is None:
+            output_types = []
+        if isinstance(output_types, type):
+            output_type = output_types
+            output_types = []
+            
+        processed_cur_inputs, processed_k_shots_examples = self._process_inputs(cur_inputs, [])
+
+        if isinstance(self.source_module, OpenAIModule):
+            outputs = self.source_module.batch_infer_step(processed_cur_inputs, instructions)
+            
+            output_types = [output_type]*len(processed_cur_inputs) if len(output_types) == 0 else output_types
+            assert len(outputs) == len(output_types), "The number of outputs should be the same as the number of output types."
+            
+            outputs = [self._convert_into_data(output, output_type) for output, output_type in zip(outputs, output_types)]
+
+            # TODO: Add support for k-shot
+            
+            # Clearing the record.
+            self.source_module.clear_history()
+
+        return outputs
+    
     # Translating the input data into image/text format.
     # Any image inputs should be tagged with the type starting with 'image...' to be correctly converted into image input.
     # Any other data will be considered into text data.
     def _process_inputs(self, 
-                   cur_inputs: list[list[tuple[str, Any]]], 
-                   k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=[]
-                ) -> tuple[list[list[dict]], list[list[Union[list[dict], str]]]]:
+                        cur_inputs: list[list[tuple[str, Any]]], 
+                        k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=[]
+                        ) -> tuple[list[list[dict]], list[list[Union[list[dict], str]]]]:
         batch_size = len(cur_inputs)
         processed_cur_inputs, processed_k_shots_examples = [], []
         for b in range(batch_size):

--- a/src/modules/modality_modules/vlm_module.py
+++ b/src/modules/modality_modules/vlm_module.py
@@ -5,10 +5,10 @@ import ast
 
 
 class VLMModule:
-    def __init__(self, source: str, model: str) -> None:
+    def __init__(self, source: str, model: str, max_concurrent_prompts: int = 1) -> None:
         self.source_module = None
         if source == 'openai': 
-            self.source_module = OpenAIModule(model)
+            self.source_module = OpenAIModule(model, max_concurrent_prompts)
 
         assert self.source_module is not None, "The source module has not been set correcly. Check required."
     
@@ -40,47 +40,54 @@ class VLMModule:
 
                 output = self.source_module.infer_step(processed_cur_inputs[b], instructions[b])
                 output_type = str if len(output_types) == 0 else output_types[b]
-                outputs.append(self._convert_into_data(output, output_type))
+                outputs.append(self.convert_into_data(output, output_type))
 
                 # Clearing the record.
                 self.source_module.clear_history()
 
         return outputs
     
-    def batch_infer_step(self, 
-                         cur_inputs: list[list[tuple[str, Any]]],
-                         k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=None,
-                         instructions: Union[str, list[str]]=None,
-                         output_types: Union[type, list[type]]=None
-                         ) -> list[str]:
+    def send_batch_job(self, 
+                        cur_inputs: list[list[tuple[str, Any]]],
+                        k_shots_examples: list[list[tuple[str, list[tuple[str, Any]]]]]=None,
+                        instructions: Union[str, list[str]]=None
+                        ) -> str:
         if k_shots_examples is None:
             k_shots_examples = []
         if instructions is None:
             instructions = []
-        
-        output_type = str
-        if output_types is None:
-            output_types = []
-        if isinstance(output_types, type):
-            output_type = output_types
-            output_types = []
-            
+        # TODO: Add support for k-shot
         processed_cur_inputs, processed_k_shots_examples = self._process_inputs(cur_inputs, [])
 
         if isinstance(self.source_module, OpenAIModule):
-            outputs = self.source_module.batch_infer_step(processed_cur_inputs, instructions)
-            
-            output_types = [output_type]*len(processed_cur_inputs) if len(output_types) == 0 else output_types
+            _, batch_job_id, num_tokens = self.source_module.batch_infer_step(processed_cur_inputs, instructions, 
+                                                                              retrieve_and_return_results=False)
+            self.source_module.clear_history()
+        return batch_job_id, num_tokens
+    
+    
+    def get_batch_job_status(self, batch_job_id: str) -> str:
+        return self.source_module.get_batch_job_status(batch_job_id)
+      
+    def retrieve_batch_results(self, 
+                               batch_job_id: str, 
+                               output_types: Union[type, list[type]]=None
+                               ) -> list[str]:
+        if isinstance(self.source_module, OpenAIModule):
+            outputs = self.source_module.retrieve_batch_results(batch_job_id)
+            output_type = str
+            if output_types is None:
+                output_types = []
+            if isinstance(output_types, type):
+                output_type = output_types
+                output_types = []
+                
+            output_types = [output_type]*len(outputs) if len(output_types) == 0 else output_types
             assert len(outputs) == len(output_types), "The number of outputs should be the same as the number of output types."
             
-            outputs = [self._convert_into_data(output, output_type) for output, output_type in zip(outputs, output_types)]
+            outputs = [self.convert_into_data(output, output_type) for output, output_type in zip(outputs, output_types)]          
 
-            # TODO: Add support for k-shot
-            
-            # Clearing the record.
-            self.source_module.clear_history()
-
-        return outputs
+            return outputs
     
     # Translating the input data into image/text format.
     # Any image inputs should be tagged with the type starting with 'image...' to be correctly converted into image input.
@@ -132,7 +139,7 @@ class VLMModule:
         return f"{key}: {value_str}"
 
     # Converting the text output into the requested form of data type.
-    def _convert_into_data(self, text: str, data_type: type) -> Any:
+    def convert_into_data(self, text: str, data_type: type) -> Any:
         try:
             if data_type == str:
                 return text

--- a/src/modules/source_modules/openai_module.py
+++ b/src/modules/source_modules/openai_module.py
@@ -2,7 +2,6 @@ from openai import OpenAI
 from typing import Any
 from PIL import Image
 from io import BytesIO
-from typing import Union
 
 import tiktoken
 import math
@@ -10,6 +9,7 @@ import numpy as np
 import base64
 import json
 import time
+import warnings
 
 CONTEXT_SIZE_MAP = {
     'gpt-4o': 128000,
@@ -27,27 +27,70 @@ CONTEXT_SIZE_MAP = {
     'gpt-4-0613': 8196
 }
 
+BATCH_QUEUE_TOKEN_DAY_LIMIT = {
+    'gpt-4o': 10000000000,
+    'gpt-4o-2024-05-13': 10000000000,
+    'gpt-4o-2024-08-06': 10000000000,
+    'chatgpt-4o-latest	': 10000000000,
+    'gpt-4o-mini': 15000000000,
+    'gpt-4o-mini-2024-07-18	': 15000000000,
+    'gpt-4-turbo': 300000000,
+    'gpt-4-turbo-2024-04-09': 300000000,
+    'gpt-4-turbo-preview': 300000000,
+    'gpt-4-0125-preview': 150000000,
+    'gpt-4-1106-preview': 150000000,
+    'gpt-4': 150000000,
+    'gpt-4-0613': 150000000
+}
 
 class OpenAIModule:
-    def __init__(self, model: str) -> None:
+    def __init__(self, model: str, max_concurrent_prompts: int = 1, max_output_tokens_per_query=128) -> None:
         if model not in CONTEXT_SIZE_MAP:
             raise KeyError(f"The model {model} is not currenly supported.")
         
-        self.history = []
+        self._max_concurrent_prompts = max_concurrent_prompts
+        self.history = [[] for _ in range(max_concurrent_prompts)]
         self.model = model
         self.max_num_tokens = CONTEXT_SIZE_MAP[model]
-        self.cur_num_tokens_cache = []
+        self.cur_num_tokens_cache = [[] for _ in range(max_concurrent_prompts)]
         self._batch_job_ids = []
         self.client = OpenAI()
         try:
             self.encoding = tiktoken.encoding_for_model(self.model)
         except KeyError:
             self.encoding = tiktoken.get_encoding('cl100k_base')
-
+        self.batch_queue_token_day_limit = BATCH_QUEUE_TOKEN_DAY_LIMIT[model]
+        self.max_output_tokens_per_query = max_output_tokens_per_query
+        
     @property
     def batch_job_ids(self):
         return self._batch_job_ids
     
+    def clear_batch_job_ids(self):
+        self._batch_job_ids = []
+    
+    @property
+    def max_concurrent_prompts(self):
+        return self._max_concurrent_prompts
+    
+    @max_concurrent_prompts.setter
+    def max_concurrent_prompts(self, value: int):
+        # append empty lists to the history and cur_num_tokens_cache
+        if value > len(self.history):
+            for _ in range(value - len(self.history)):
+                self.history.append([])
+                self.cur_num_tokens_cache.append([])
+        # remove the last elements from the history and cur_num_tokens_cache
+        elif value < len(self.history):
+            values_to_remove = len(self.history) - value
+            warnings.warn(f'Removing the last {values_to_remove} elements from the history '
+                          f'and cur_num_tokens_cache to match max concurrent prompts')
+            for _ in range(values_to_remove):
+                self.history.pop()
+                self.cur_num_tokens_cache.pop()
+        
+        self._max_concurrent_prompts = value
+        
     # One inference step.
     def infer_step(self, inputs: list[tuple[str, Any]], system_prompt: str=None) -> str:
         assert len(inputs) > 0, "The inputs cannot be empty. The inputs should be included."
@@ -57,23 +100,31 @@ class OpenAIModule:
         return response
     
     def batch_infer_step(self, inputs_batch: list[list[tuple[str, Any]]], 
-                         system_prompt: Union[str, list]=None) -> str:
+                         system_prompts: list[str],
+                         retrieve_and_return_results: bool = True) -> tuple[list[str], str, int]:
         assert len(inputs_batch) > 0, "There must be at least one input in the batch."
+        assert len(inputs_batch) <= len(self.history), "The batch size should be <= the maximum concurrent prompts."
         for inputs in inputs_batch:
             assert len(inputs) > 0, "The inputs cannot be empty. The inputs should be included."
-        if isinstance(system_prompt, list):
-            assert len(inputs_batch) == len(system_prompt), "The number of system prompts should equal batch size."
+        assert len(inputs_batch) == len(system_prompts), "The number of system prompts should equal batch size."
         
-        for inputs in inputs_batch:
-            self.add_data('input', inputs)
+        for i, inputs in enumerate(inputs_batch):
+            self.add_data('input', inputs, i)
+        input_tokens = sum([sum(num_tokens) for num_tokens in self.cur_num_tokens_cache])
         
-        responses = self._get_batch_response_from_api(system_prompt)
-        for response in responses:
-            self.add_data('output', [('text', response)])
-        return responses
+        responses, batch_job_id = self._execute_batch_job(system_prompts, 
+                                                          retrieve_and_return_results=retrieve_and_return_results)
+        
+        # adding max out tokens to the count because we may not know the actual number of out tokens
+        self.batch_queue_token_day_limit -= (input_tokens + self.max_output_tokens_per_query)
+        
+        for r, response in enumerate(responses):
+            self.add_data('output', [('text', response)], r)
+        return responses, batch_job_id, input_tokens
         
     # Adding new data in the context history.
-    def add_data(self, type: str, data: list[tuple[str, Any]]) -> None:
+    def add_data(self, type: str, data: list[tuple[str, Any]], idx=0) -> None:
+        assert idx < len(self.history), "Index should be less than the maximum concurrent prompts."
         assert type == 'input' or type == 'output', "The data type should be either 'input' or 'output'."
         role = 'user' if type == 'input' else 'assistant'
         message = {'role': role, 'content': []}
@@ -90,64 +141,80 @@ class OpenAIModule:
                 image_sizes.append(image_size)
             else:
                 raise NotImplementedError("OpenAIModule only supports the data type 'text' or 'image'.")
-        self.history.append(message)
-        self.cur_num_tokens_cache.append(self._get_num_tokens(message['role'], message['content'], image_sizes))
-                
-        assert len(self.history) == len(self.cur_num_tokens_cache), "The chat history and num tokens cache should be synced."
+            
+        num_tokens = self._get_num_tokens(role, message['content'], image_sizes)
+        if self.batch_queue_token_day_limit - num_tokens < 0:
+            raise Exception('Exceeded token per day limit') 
 
+        self.history[idx].append(message)
+        self.cur_num_tokens_cache[idx].append(num_tokens)
+        assert len(self.history[idx]) == len(self.cur_num_tokens_cache[idx]), \
+            "The chat history and num tokens cache should be synced."
+                
     # Clearing the history.
     def clear_history(self) -> None:
-        self.history = []
-        self.cur_num_tokens_cache = []
+        self.history = [[] for _ in range(self._max_concurrent_prompts)]
+        self.cur_num_tokens_cache = [[] for _ in range(self._max_concurrent_prompts)]
 
     # Calling the chat completion API.
     def _get_response_from_api(self, system_prompt: str=None) -> str:
         start_idx = self._find_starting_point(system_prompt)
         system_message = []
         if system_prompt is not None:
-            system_message.append({'role': 'user', 'content': system_prompt})
+            system_message.append({'role': 'system', 'content': system_prompt})
 
-        messages = system_message + self.history[start_idx:]
+        messages = system_message + self.history[0][start_idx:]
         response = self.client.chat.completions.create(
             model=self.model,
             messages=messages,
-            max_tokens=128
+            max_tokens=self.max_output_tokens_per_query
         )
 
         return response.choices[0].message.content
     
-    def _get_batch_response_from_api(self, system_prompt: Union[str, list[str]]=None):
-        start_idx = self._find_starting_point(system_prompt)
+    def get_batch_job_status(self, batch_job_id: str) -> bool:
+        batch_job = self.client.batches.retrieve(batch_job_id)
+        return batch_job.status
+    
+    def retrieve_batch_results(self, batch_job_id: str) -> list[str]:
+        assert self.get_batch_job_status(batch_job_id) == 'completed', \
+            "The batch job should be completed to retrieve the results."
+        batch_job = self.client.batches.retrieve(batch_job_id)
+        result = self.client.files.content(batch_job.output_file_id)
+        
+        responses = []
+        for response in result.iter_lines():
+            response = json.loads(response)
+            response = response['response']['body']['choices'][0]['message']['content']
+            responses.append(response)
+        return responses
+        
+    def _execute_batch_job(self, system_prompts: list[str], 
+                           retrieve_and_return_results: bool) -> tuple[list[str], str]:
+        start_idxs = []
+        for s, system_prompt in enumerate(system_prompts):
+            start_idx = self._find_starting_point(system_prompt, idx=s)
+            start_idxs.append(start_idx)
+            
         system_messages = []
-        if system_prompt is not None:
-            if isinstance(system_prompt, str):
-                system_prompt = [system_prompt]
-            for prompt in system_prompt:
-                system_messages.append([{'role': 'system', 'content': prompt}])
+        for prompt in system_prompts:
+            system_messages.append([{'role': 'system', 'content': prompt}])
 
-        messages_batch = self.history[start_idx:]
         file_name = "batch_queries.jsonl"
         with open(file_name, 'w') as file:
-            for i, messages in enumerate(messages_batch):
-                if len(system_messages) == 0:
-                    system_message = []
-                else:
-                    # If there is one system message, repeat it for all the messages. 0 % 1 = 0, 1 % 1 = 0 ...
-                    # If the numbers are equal, use them as is. 0 % 3 = 0, 1 % 3 = 1, 2 % 3 = 2
-                    # Otherwise, they will be round robined (probably not useful).
-                    system_message = system_messages[i % len(system_messages)]
-                    
+            for i, start_idx in enumerate(start_idxs):
+                messages = self.history[i][start_idx:]
                 task = {
                     "custom_id": f"task-{i}",
                     "method": "POST",
                     "url": "/v1/chat/completions",
                     "body": {
                         "model": self.model,
-                        "max_tokens": 128,
+                        "max_tokens": self.max_output_tokens_per_query,
                         "response_format": { 
                             "type": "text"
                         },
-                        "messages": system_message + [messages]
+                        "messages": system_messages[i] + messages
                     }
                 }
         
@@ -162,24 +229,33 @@ class OpenAIModule:
             endpoint="/v1/chat/completions",
             completion_window="24h"
         )
-        self._batch_job_ids.append(batch_job.id)
-        batch_job = self.client.batches.retrieve(batch_job.id)
         
-        sleep_time = 1
-        while batch_job.status != 'completed':
-            # Exponential backoff for polling the batch job status.
-            time.sleep(sleep_time)
-            sleep_time *= 1.5
-            batch_job = self.client.batches.retrieve(batch_job.id)
-
-        result = self.client.files.content(batch_job.output_file_id)
+        batch_job_id = batch_job.id
+        self._batch_job_ids.append(batch_job_id)
         
-        responses = []
-        for response in result.iter_lines():
-            response = json.loads(response)
-            response = response['response']['body']['choices'][0]['message']['content']
-            responses.append(response)
-        return responses
+        if retrieve_and_return_results:
+            batch_job = self.client.batches.retrieve(batch_job_id)
+            
+            sleep_time = 1
+            while batch_job.status != 'completed':
+                if batch_job.status == 'failed':
+                    raise Exception(f"Batch job {batch_job_id} failed.")
+                
+                # Exponential backoff for polling the batch job status.
+                time.sleep(sleep_time)
+                sleep_time *= 1.5
+                batch_job = self.client.batches.retrieve(batch_job_id)
+                
+            result = self.client.files.content(batch_job.output_file_id)
+            
+            responses = []
+            for response in result.iter_lines():
+                response = json.loads(response)
+                response = response['response']['body']['choices'][0]['message']['content']
+                responses.append(response)
+            return responses, batch_job_id
+        else:
+            return [], batch_job_id
         
     # Calculating the number of tokens in one message.
     def _get_num_tokens(self, role: str, content: list[dict], image_sizes: list[tuple[int, int]]=[]) -> int:
@@ -239,17 +315,18 @@ class OpenAIModule:
         return f"data:image/png;base64,{base64.b64encode(buffer.getvalue()).decode()}"
     
     # Finding the starting index of the chat history for adjusting the input size.
-    def _find_starting_point(self, system_prompt: str=None, max_response_tokens: int=128) -> int:
+    def _find_starting_point(self, system_prompt: str=None, max_response_tokens: int=128, idx=0) -> int:
         num_tokens = 0
         if system_prompt is not None: 
             num_tokens = self._get_num_tokens(role='system', content=[{'type': 'text', 'text': system_prompt}])
-            assert num_tokens < self.max_num_tokens, "The number of tokens in the system message must be smaller than the context size."
-        
-        start_idx = len(self.cur_num_tokens_cache)
-        for i in range(len(self.cur_num_tokens_cache)-1, -1, -1):
-            if num_tokens + self.cur_num_tokens_cache[i] > (self.max_num_tokens - max_response_tokens):
+            assert num_tokens < self.max_num_tokens, \
+                "The number of tokens in the system message must be smaller than the context size."
+
+        start_idx = len(self.cur_num_tokens_cache[idx])
+        for i in range(len(self.cur_num_tokens_cache[idx])-1, -1, -1):
+            if num_tokens + self.cur_num_tokens_cache[idx][i] > (self.max_num_tokens - max_response_tokens):
                 break
-            num_tokens += self.cur_num_tokens_cache[i]
+            num_tokens += self.cur_num_tokens_cache[idx][i]
             start_idx = i
 
         return start_idx

--- a/src/modules/source_modules/openai_module.py
+++ b/src/modules/source_modules/openai_module.py
@@ -149,7 +149,6 @@ class OpenAIModule:
         )
         self._batch_job_ids.append(batch_job.id)
         batch_job = self.client.batches.retrieve(batch_job.id)
-        # batch_job = self.client.batches.retrieve("batch_678dffece0348190821239e587d42582")
         
         sleep_time = 1
         while batch_job.status != 'completed':
@@ -159,7 +158,6 @@ class OpenAIModule:
             batch_job = self.client.batches.retrieve(batch_job.id)
 
         result = self.client.files.content(batch_job.output_file_id)
-        # result = self.client.files.content('file-3NncBe1grAkYVoCd1JMur9')
         
         responses = []
         for response in result.iter_lines():

--- a/tst/modules/dataset_modules/openx_module_test.py
+++ b/tst/modules/dataset_modules/openx_module_test.py
@@ -1,10 +1,14 @@
+import json
 import os
+from pathlib import Path
 import sys
+
+import tensorflow as tf
 ROOT_DIR = os.getcwd()
 sys.path.append(ROOT_DIR)
 os.environ["OPENAI_API_KEY"] = "random-api-key"
 
-from src.modules.dataset_modules.openx_module import OpenXModule
+from src.modules.dataset_modules.openx_module import OpenXModule, BatchInfo, OpenXBatchModule
 from src.modules.modality_modules.vlm_module import VLMModule
 from unittest.mock import MagicMock
 
@@ -482,5 +486,186 @@ class OpenXModuleTest(unittest.TestCase):
         self.assertEqual(i, 31)  # Stopping check.
 
 
+class BatchInfoTest(unittest.TestCase):
+    def test_BatchInfo(self):
+        dataset_name, batch_num, batch_id, output_types, token_count, is_lasts, labels, num_inputs, save_root = \
+            "dataset1", 1, "batch123", [str, str, str], 33, [False, False, False], [tf.constant(1), tf.constant(2), tf.constant(3)], 3, "."
+        
+        batch_info = BatchInfo(dataset_name, batch_num, batch_id, output_types, token_count, 
+                               [int(is_last) for is_last in is_lasts], [label.numpy() for label in labels], 
+                               num_inputs, save_root)
+        fp = batch_info.save_to_file()
+        self.assertTrue(Path(fp).exists())
+        
+        data = np.load(fp, allow_pickle=True)
+        self.assertEqual(data['dataset_name'].item(), dataset_name)
+        self.assertEqual(data['batch_num'].item(), batch_num)
+        self.assertEqual(data['batch_id'].item(), batch_id)
+        self.assertEqual(list(data['output_types']), output_types)
+        self.assertEqual(data['token_count'].item(), token_count)
+        self.assertEqual([bool(is_last) for is_last in data['is_lasts']], is_lasts)
+        self.assertEqual([tf.convert_to_tensor(label) for label in data['labels']], labels)
+        self.assertEqual(data['num_inputs'].item(), num_inputs)
+
+
+class OpenXBatchModuleTest(unittest.TestCase):
+    def test_constructor(self):
+        # Test for VLMModule with OpenAIModule.
+        disk_root_dir = "/mnt/disks"
+        modality = "vlm"
+        source = "openai"
+        model = 'gpt-4o-2024-05-13'
+        batch_size = 3
+        k_shots = 2
+        module = OpenXBatchModule(disk_root_dir, modality, source, model, batch_size, k_shots)
+        self.assertEqual(module.disk_root_dir, disk_root_dir)
+        self.assertTrue(isinstance(module.modality_module, VLMModule))
+        self.assertEqual(module.batch_size, batch_size)
+        self.assertEqual(module.k_shots, k_shots)
+    
+    def test_process_batch_zero_shot(self):
+        batch = {
+            'continuous_observation': [
+                [np.random.random(size=(16)) for i in range(4)],
+                [np.random.random(size=(16)) for i in range(1)],
+                [np.random.random(size=(16)) for i in range(3)],
+                [np.random.random(size=(16)) for i in range(5)],
+            ],
+            'text_observation': [
+                ['test-text1' for i in range(4)],
+                ['test-text1' for i in range(1)],
+                ['test-text2' for i in range(3)],
+                ['test-text2' for i in range(5)],
+            ],
+            'image_observation': [
+                [np.random.randint(256, size=(128,128,3)) for i in range(4)],
+                [np.random.randint(256, size=(128,128,3)) for i in range(1)],
+                [np.random.randint(256, size=(128,128,3)) for i in range(3)],
+                [np.random.randint(256, size=(128,128,3)) for i in range(5)],
+            ],
+            'unknown': [
+                [None for i in range(4)],
+                [None for i in range(1)],
+                [None for i in range(3)],
+                [None for i in range(5)]
+            ],
+            'action': [
+                [np.random.random(size=(8)) for i in range(4)],
+                [np.random.random(size=(8)) for i in range(1)],
+                [np.random.random(size=(8)) for i in range(3)],
+                [np.random.random(size=(8)) for i in range(5)],
+            ],
+            'reward': [
+                [random.random() for i in range(4)],
+                [random.random() for i in range(1)],
+                [random.random() for i in range(3)],
+                [random.random() for i in range(5)]
+            ],
+            'is_last': [
+                [False, False, False, True],
+                [True],
+                [False, False, True],
+                [False, False, False, False, True]
+            ]
+        }
+
+        module = OpenXBatchModule(
+            disk_root_dir='/mnt/disks', 
+            modality='vlm', 
+            source='openai',
+            model='gpt-4o-2024-05-13', 
+            batch_size=4, 
+            k_shots=0
+        )
+        dataset = 'test-dataset'
+
+        def side_effect(dataset, env_name):
+            if env_name == 'test-text1':
+                return "test-instruction-1"
+            elif env_name == 'test-text2':
+                return "test-instruction-2"
+            else:
+                return "dummy-instruction"
+        module._get_vlm_instruction = MagicMock(side_effect=side_effect)
+        module._get_output_type = MagicMock(return_value=list)
+
+        for i, (cur_inputs, k_shots_examples, instructions, labels, idxs, output_types, is_lasts) in enumerate(module._process_batch(batch, dataset)):
+            self.assertEqual(k_shots_examples, [])
+            
+            if i == 0:  # episode 0
+                self.assertEqual(idxs, [0, 1, 2, 3])
+                self.assertEqual(instructions, ["test-instruction-1", "test-instruction-1", "test-instruction-1", "test-instruction-1"])
+                self.assertEqual(labels, batch['action'][i])
+                self.assertEqual(output_types, [list, list, list, list])
+                self.assertEqual(is_lasts, batch['is_last'][i])
+                self.assertEqual(cur_inputs, [
+                    [
+                        ('image_observation', batch['image_observation'][i][t]), 
+                        ('continuous_observation', batch['continuous_observation'][i][t]), 
+                        ('text_observation', batch['text_observation'][i][t])
+                    ] for t in range(4)
+                ])
+
+            elif i == 1:  # episode 1
+                self.assertEqual(idxs, [0])
+                self.assertEqual(instructions, ["test-instruction-1"])
+                self.assertEqual(labels, batch['action'][i])
+                self.assertEqual(output_types, [list])
+                self.assertEqual(is_lasts, batch['is_last'][i])
+                self.assertEqual(cur_inputs, [
+                    [
+                        ('image_observation', batch['image_observation'][i][t]), 
+                        ('continuous_observation', batch['continuous_observation'][i][t]), 
+                        ('text_observation', batch['text_observation'][i][t])
+                    ] for t in range(1)
+                ]) 
+                
+            elif i == 2:  # episode 2
+                self.assertEqual(idxs, [0, 1, 2])
+                self.assertEqual(instructions, ["test-instruction-2", "test-instruction-2", "test-instruction-2"])
+                self.assertEqual(labels, batch['action'][i])
+                self.assertEqual(output_types, [list, list, list])
+                self.assertEqual(is_lasts, batch['is_last'][i])
+                self.assertEqual(cur_inputs, [
+                    [
+                        ('image_observation', batch['image_observation'][i][t]), 
+                        ('continuous_observation', batch['continuous_observation'][i][t]), 
+                        ('text_observation', batch['text_observation'][i][t])
+                    ] for t in range(3)
+                ])
+                
+            elif i == 3:  # episode 3 first 4 prompts
+                self.assertEqual(idxs, [0, 1, 2, 3])
+                self.assertEqual(instructions, ["test-instruction-2", "test-instruction-2", "test-instruction-2", "test-instruction-2"])
+                self.assertEqual(labels, batch['action'][i][:4])
+                self.assertEqual(output_types, [list, list, list, list])
+                self.assertEqual(is_lasts, batch['is_last'][i][:4])
+                self.assertEqual(cur_inputs, [
+                    [
+                        ('image_observation', batch['image_observation'][i][t]), 
+                        ('continuous_observation', batch['continuous_observation'][i][t]), 
+                        ('text_observation', batch['text_observation'][i][t])
+                    ] for t in range(4)
+                ])
+                
+            elif i == 4:  # episode 3 remaining 1 prompt
+                # still on episode 3, since batch size exceeded num timesteps
+                e = i - 1
+                self.assertEqual(idxs, [0])
+                self.assertEqual(instructions, ["test-instruction-2"])
+                self.assertEqual(labels, batch['action'][e][-1:])
+                self.assertEqual(output_types, [list])
+                self.assertEqual(is_lasts, batch['is_last'][e][-1:])
+                self.assertEqual(cur_inputs, [
+                    [
+                        ('image_observation', batch['image_observation'][e][t]), 
+                        ('continuous_observation', batch['continuous_observation'][e][t]), 
+                        ('text_observation', batch['text_observation'][e][t])
+                    ] for t in range(4,5)
+                ])
+        self.assertEqual(i, 4)  # Stopping check.
+    
+    
+            
 if __name__=="__main__":
     unittest.main()

--- a/tst/modules/source_modules/openai_module_test.py
+++ b/tst/modules/source_modules/openai_module_test.py
@@ -21,16 +21,16 @@ class OpenAIModuleTest(unittest.TestCase):
         module = OpenAIModule(model)
         self.assertEqual(module.model, model)
         self.assertEqual(module.max_num_tokens, 128000)
-        self.assertEqual(module.history, [])
-        self.assertEqual(module.cur_num_tokens_cache, [])
+        self.assertEqual(module.history, [[]])
+        self.assertEqual(module.cur_num_tokens_cache, [[]])
         self.assertEqual(module.encoding.name, 'o200k_base')
 
         model = "gpt-4"
         module = OpenAIModule(model)
         self.assertEqual(module.model, model)
         self.assertEqual(module.max_num_tokens, 8196)
-        self.assertEqual(module.history, [])
-        self.assertEqual(module.cur_num_tokens_cache, [])
+        self.assertEqual(module.history, [[]])
+        self.assertEqual(module.cur_num_tokens_cache, [[]])
         self.assertEqual(module.encoding.name, 'cl100k_base')
         
     def test_infer_step_with_texts(self):
@@ -47,12 +47,12 @@ class OpenAIModuleTest(unittest.TestCase):
             module._get_response_from_api = MagicMock(return_value=f"This is a response {q} for single query testing.")
             response = module.infer_step([('text', query)], system_prompt)
             self.assertEqual(response, f"This is a response {q} for single query testing.")
-            self.assertEqual(module.history[q*2], {'role': 'user', 'content': [{'type': 'text', 'text': queries[q]}]})
-            self.assertEqual(module.history[q*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
-            self.assertEqual(module.cur_num_tokens_cache[q*2], module._get_num_tokens('user', [{'type': 'text', 'text': query}]))
-            self.assertEqual(module.cur_num_tokens_cache[q*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
-            self.assertEqual(len(module.history), q*2+2)
-            self.assertEqual(len(module.cur_num_tokens_cache), q*2+2)
+            self.assertEqual(module.history[0][q*2], {'role': 'user', 'content': [{'type': 'text', 'text': queries[q]}]})
+            self.assertEqual(module.history[0][q*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
+            self.assertEqual(module.cur_num_tokens_cache[0][q*2], module._get_num_tokens('user', [{'type': 'text', 'text': query}]))
+            self.assertEqual(module.cur_num_tokens_cache[0][q*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
+            self.assertEqual(len(module.history[0]), q*2+2)
+            self.assertEqual(len(module.cur_num_tokens_cache[0]), q*2+2)
 
         module = OpenAIModule(model)
         multi_queries = [
@@ -64,139 +64,93 @@ class OpenAIModuleTest(unittest.TestCase):
             response = module.infer_step([('text', query) for query in multi_query], system_prompt)
             self.assertEqual(response, f"This is a response {m} for multi query testing.")
             expected_content = [{'type': 'text', 'text': query} for query in multi_query]
-            self.assertEqual(module.history[m*2], {'role': 'user', 'content': expected_content})
-            self.assertEqual(module.history[m*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
-            self.assertEqual(module.cur_num_tokens_cache[m*2], module._get_num_tokens('user', expected_content))
-            self.assertEqual(module.cur_num_tokens_cache[m*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
-            self.assertEqual(len(module.history), m*2+2)
-            self.assertEqual(len(module.cur_num_tokens_cache), m*2+2)
+            self.assertEqual(module.history[0][m*2], {'role': 'user', 'content': expected_content})
+            self.assertEqual(module.history[0][m*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
+            self.assertEqual(module.cur_num_tokens_cache[0][m*2], module._get_num_tokens('user', expected_content))
+            self.assertEqual(module.cur_num_tokens_cache[0][m*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
+            self.assertEqual(len(module.history[0]), m*2+2)
+            self.assertEqual(len(module.cur_num_tokens_cache[0]), m*2+2)
 
     def test_batch_infer_with_texts(self):
-        system_prompt = "This is a test system prompt."
         model = "gpt-4o-2024-05-13"
         
         # Single object queries
-        module = OpenAIModule(model)
-        queries = [
-            "What's your name?",
-            "What is the advantages of Python language?",
-            "What is the definition of a generalist foundation model?"
-        ]
-        
-        query_batches = [queries, queries[:1], queries[-2:]]
-        prev_history_count = 0
-        for qb, queries in enumerate(query_batches):
-            mock_responses, model_inputs = [], []
-            for q, query in enumerate(queries):
-                mock_responses.append(f"This is a response {q} for batch {qb}.")
-                
-                model_inputs.append([('text', query)])
-            
-            module._get_batch_response_from_api = MagicMock(return_value=mock_responses[:])
-            responses = module.batch_infer_step(model_inputs, system_prompt)
-            
-            self.assertEqual(responses, mock_responses)
-            
-            for q, query in enumerate(queries):
-                query_content = [{'type': 'text', 'text': query}]
-                self.assertEqual(module.history[prev_history_count+q], {'role': 'user', 'content': query_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q], module._get_num_tokens('user', query_content))
-            
-                resp_content = [{'type': 'text', 'text': responses[q]}]
-                self.assertEqual(module.history[prev_history_count+q+len(queries)], {'role': 'assistant', 'content': resp_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q+len(queries)], module._get_num_tokens('assistant', resp_content))
-            
-            self.assertEqual(len(module.history), prev_history_count + len(queries) * 2)
-            self.assertEqual(len(module.cur_num_tokens_cache), prev_history_count + len(queries) * 2)
-            
-            prev_history_count += len(queries) * 2
-            
-        # Multi-object queries
-        system_prompt = "This is a test system prompt."
-        model = "gpt-4o-2024-05-13"
-        
-        module = OpenAIModule(model)
-        multi_queries = [
-            ["What is the definition of a generalist foundation model?"],
-            ["This is a user message 1", "Additional user message."],
-            ["What's your name?", "My name is Python.", "Nice to meet you."]
-        ]
-        
-        query_batches = [multi_queries, multi_queries[:1], multi_queries[-2:]]
-        prev_history_count = 0
-        for qb, queries in enumerate(query_batches):
-            mock_responses, model_inputs = [], []
-            for q, query in enumerate(queries):
-                mock_response = f"This is a response {q} for batch {qb}."
-                mock_responses.append(mock_response)
-                
-                model_inputs.append([('text', obj) for obj in query])
-            
-            module._get_batch_response_from_api = MagicMock(return_value=mock_responses[:])
-            responses = module.batch_infer_step(model_inputs, system_prompt)
-            
-            self.assertEqual(responses, mock_responses)
-            
-            for q, query in enumerate(queries):
-                query_content = [{'type': 'text', 'text': obj} for obj in query]
-                self.assertEqual(module.history[prev_history_count+q], {'role': 'user', 'content': query_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q], module._get_num_tokens('user', query_content))
-            
-                resp_content = [{'type': 'text', 'text': responses[q]}]
-                self.assertEqual(module.history[prev_history_count+q+len(queries)], {'role': 'assistant', 'content': resp_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q+len(queries)], module._get_num_tokens('assistant', resp_content))
-            
-            self.assertEqual(len(module.history), prev_history_count + len(queries) * 2)
-            self.assertEqual(len(module.cur_num_tokens_cache), prev_history_count + len(queries) * 2)
-            
-            prev_history_count += len(queries) * 2
-    
-    def test_batch_infer_with_multiple_system_prompts(self):
-        model = "gpt-4o-2024-05-13"
-        module = OpenAIModule(model)
-        
-        # Single object queries with multiple system prompts
-        queries = [
-            "What's your name?",
-            "What is the advantages of Python language?",
-            "What is the definition of a generalist foundation model?"
-        ]
-        
+        module = OpenAIModule(model, max_concurrent_prompts=3)
         system_prompts = [
             'This is a test system prompt 1.', 
             'This is a test system prompt 2.', 
             'This is a test system prompt 3.'
         ]
         
-        query_batches = [queries, queries[:1], queries[-2:]]
-        system_prompts_batches = [system_prompts, system_prompts[:1], system_prompts[-2:]]
+        queries = [
+            "What's your name?",
+            "What is the advantages of Python language?",
+            "What is the definition of a generalist foundation model?"
+        ]
+
+        mock_responses, model_inputs = [], []
+        for q, query in enumerate(queries):
+            mock_responses.append(f"This is a response {q} for single query testing.")
+            
+            model_inputs.append([('text', query)])
         
-        prev_history_count = 0
-        for qb, queries in enumerate(query_batches):
-            mock_responses, model_inputs = [], []
-            for q, query in enumerate(queries):
-                mock_responses.append(f"This is a response {q} for batch {qb}.")
-                
-                model_inputs.append([('text', query)])
+        module._execute_batch_job = MagicMock(return_value=(mock_responses[:], 'batchid123'))
+        responses, batch_job_id, input_tokens = module.batch_infer_step(model_inputs, system_prompts, retrieve_and_return_results=True)
+        self.assertEqual(batch_job_id, 'batchid123')
+        self.assertEqual(responses, mock_responses)
+        total_input_tokens = sum([module._get_num_tokens('user', [{'type': 'text', 'text': query}]) for query in queries])
+        self.assertEqual(input_tokens, total_input_tokens)
+        
+        for q, query in enumerate(queries):
+            self.assertEqual(responses[q], f"This is a response {q} for single query testing.")
+            self.assertEqual(module.history[q][0], {'role': 'user', 'content': [{'type': 'text', 'text': query}]})
+            self.assertEqual(module.history[q][1], {'role': 'assistant', 'content': [{'type': 'text', 'text': responses[q]}]})
+            self.assertEqual(module.cur_num_tokens_cache[q][0], module._get_num_tokens('user', [{'type': 'text', 'text': query}]))
+            self.assertEqual(module.cur_num_tokens_cache[q][1], module._get_num_tokens('assistant', [{'type': 'text', 'text': responses[q]}]))
+            self.assertEqual(len(module.history[q]), 2)
+            self.assertEqual(len(module.cur_num_tokens_cache[q]), 2)
             
-            module._get_batch_response_from_api = MagicMock(return_value=mock_responses[:])
-            responses = module.batch_infer_step(model_inputs, system_prompts_batches[qb])
+        # Multi-object queries
+        model = "gpt-4o-2024-05-13"
+        
+        module = OpenAIModule(model, max_concurrent_prompts=3)
+        system_prompts = [
+            'This is a test system prompt 1.', 
+            'This is a test system prompt 2.', 
+            'This is a test system prompt 3.'
+        ]
+        
+        multi_queries = [
+            ["What is the definition of a generalist foundation model?"],
+            ["This is a user message 1", "Additional user message."],
+            ["What's your name?", "My name is Python.", "Nice to meet you."]
+        ]
+        
+        mock_responses, model_inputs = [], []
+        for m, multi_query in enumerate(multi_queries):
+            mock_response = f"This is a response {m} for multi query testing."
+            mock_responses.append(mock_response)
             
-            self.assertEqual(responses, mock_responses)
-            
-            for q, query in enumerate(queries):
-                query_content = [{'type': 'text', 'text': query}]
-                self.assertEqual(module.history[prev_history_count+q], {'role': 'user', 'content': query_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q], module._get_num_tokens('user', query_content))
-            
-                resp_content = [{'type': 'text', 'text': responses[q]}]
-                self.assertEqual(module.history[prev_history_count+q+len(queries)], {'role': 'assistant', 'content': resp_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q+len(queries)], module._get_num_tokens('assistant', resp_content))
-            
-            self.assertEqual(len(module.history), prev_history_count + len(queries) * 2)
-            self.assertEqual(len(module.cur_num_tokens_cache), prev_history_count + len(queries) * 2)
-            
-            prev_history_count += len(queries) * 2
+            model_inputs.append([('text', obj) for obj in multi_query])
+        
+        module._execute_batch_job = MagicMock(return_value=(mock_responses[:], 'batchid123'))
+        responses, batch_job_id, input_tokens = module.batch_infer_step(model_inputs, system_prompts, retrieve_and_return_results=True)
+        self.assertEqual(batch_job_id, 'batchid123')
+        self.assertEqual(responses, mock_responses)
+        total_input_tokens = 0
+        for multi_query in multi_queries:
+            total_input_tokens += module._get_num_tokens('user', [{'type': 'text', 'text': obj} for obj in multi_query])
+        self.assertEqual(input_tokens, total_input_tokens)
+        
+        for m, multi_query in enumerate(multi_queries):
+            self.assertEqual(responses[m], f"This is a response {m} for multi query testing.")
+            expected_content = [{'type': 'text', 'text': query} for query in multi_query]
+            self.assertEqual(module.history[m][0], {'role': 'user', 'content': expected_content})
+            self.assertEqual(module.history[m][1], {'role': 'assistant', 'content': [{'type': 'text', 'text': responses[m]}]})
+            self.assertEqual(module.cur_num_tokens_cache[m][0], module._get_num_tokens('user', expected_content))
+            self.assertEqual(module.cur_num_tokens_cache[m][1], module._get_num_tokens('assistant', [{'type': 'text', 'text': responses[m]}]))
+            self.assertEqual(len(module.history[m]), 2)
+            self.assertEqual(len(module.cur_num_tokens_cache[m]), 2)
             
     def test_infer_step_with_images(self):
         system_prompt = "This is a test system prompt."
@@ -233,36 +187,35 @@ class OpenAIModuleTest(unittest.TestCase):
                 ('image', np.random.randint(256, size=(128, 64, 3)).astype(np.uint8))
             ]
         ]
+        
         for q, query in enumerate(queries):
             module._get_response_from_api = MagicMock(return_value=f"This is a response {q}.")
             response = module.infer_step(query, system_prompt)
             self.assertEqual(response, f"This is a response {q}.")
-            self.assertEqual(module.history[q*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
-            self.assertEqual(module.history[q*2]['role'], 'user')
-            self.assertTrue(isinstance(module.history[q*2]['content'], list))
+            self.assertEqual(module.history[0][q*2+1], {'role': 'assistant', 'content': [{'type': 'text', 'text': response}]})
+            self.assertEqual(module.history[0][q*2]['role'], 'user')
+            self.assertTrue(isinstance(module.history[0][q*2]['content'], list))
 
             for o, obj in enumerate(query):
                 if obj[0] == 'text':
-                    self.assertEqual(module.history[q*2]['content'][o], {'type': 'text', 'text': obj[1]})
+                    self.assertEqual(module.history[0][q*2]['content'][o], {'type': 'text', 'text': obj[1]})
                 elif obj[0] == 'image':
-                    self.assertEqual(module.history[q*2]['content'][o]['type'], 'image_url')
-                    self.assertTrue(isinstance(module.history[q*2]['content'][o]['image_url']['url'], str))
-                    self.assertTrue(module.history[q*2]['content'][o]['image_url']['url'].startswith('data:image/png;base64,'))
+                    self.assertEqual(module.history[0][q*2]['content'][o]['type'], 'image_url')
+                    self.assertTrue(isinstance(module.history[0][q*2]['content'][o]['image_url']['url'], str))
+                    self.assertTrue(module.history[0][q*2]['content'][o]['image_url']['url'].startswith('data:image/png;base64,'))
 
-            self.assertEqual(module.cur_num_tokens_cache[q*2], module._get_num_tokens(
+            self.assertEqual(module.cur_num_tokens_cache[0][q*2], module._get_num_tokens(
                 'user',
-                 module.history[q*2]['content'], 
+                 module.history[0][q*2]['content'], 
                 [(obj[1].shape[0], obj[1].shape[1]) for obj in query if obj[0] == 'image']
             ))
-            self.assertEqual(module.cur_num_tokens_cache[q*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
+            self.assertEqual(module.cur_num_tokens_cache[0][q*2+1], module._get_num_tokens('assistant', [{'type': 'text', 'text': response}]))
 
-            self.assertEqual(len(module.history), q*2+2)
-            self.assertEqual(len(module.cur_num_tokens_cache), q*2+2)
+            self.assertEqual(len(module.history[0]), q*2+2)
+            self.assertEqual(len(module.cur_num_tokens_cache[0]), q*2+2)
 
     def test_batch_infer_with_images(self):
-        system_prompt = "This is a test system prompt."
         model = "gpt-4o-2024-05-13"
-        module = OpenAIModule(model)
 
         queries = [
             [
@@ -294,53 +247,51 @@ class OpenAIModuleTest(unittest.TestCase):
                 ('image', np.random.randint(256, size=(128, 64, 3)).astype(np.uint8))
             ]
         ]
-
-        query_batches = [queries, queries[:2], queries[:1]]
-        prev_history_count = 0
-        for qb, queries in enumerate(query_batches):
-            mock_responses, model_inputs = [], []
-            for q, query in enumerate(queries):
-                mock_response = f"This is a response {q} for batch {qb}."
-                mock_responses.append(mock_response)
-                
-                model_inputs.append(query)
-            module._get_batch_response_from_api = MagicMock(return_value=mock_responses[:])
-            responses = module.batch_infer_step(model_inputs, system_prompt)
+        system_prompts = ["This is a test system prompt." for _ in range(len(queries))]
+        module = OpenAIModule(model, max_concurrent_prompts=len(queries))
+        mock_responses, model_inputs = [], []
+        for q, query in enumerate(queries):
+            mock_response = f"This is a response {q}."
+            mock_responses.append(mock_response)
             
-            self.assertEqual(responses, mock_responses)
-
-            for q, query in enumerate(queries):
-                self.assertEqual(module.history[prev_history_count+q]['role'], 'user')
-                self.assertTrue(isinstance(module.history[prev_history_count+q]['content'], list))
-                
-                shapes = []
-                for o, obj in enumerate(query):
-                    if obj[0] == 'text':
-                        self.assertEqual(module.history[prev_history_count+q]['content'][o], 
-                                         {'type': 'text', 'text': obj[1]})
-                    elif obj[0] == 'image':
-                        obj_history_content = module.history[prev_history_count+q]['content'][o]
-                        self.assertEqual(obj_history_content['type'], 'image_url')
-
-                        img_url = obj_history_content['image_url']['url']
-                        self.assertTrue(isinstance(img_url, str))
-                        self.assertTrue(img_url.startswith('data:image/png;base64,'))
-                    
-                        shapes.append((obj[1].shape[0], obj[1].shape[1]))
-
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q], 
-                                 module._get_num_tokens('user', 
-                                                        module.history[prev_history_count+q]['content'], 
-                                                        shapes))                                
-
-                resp_content = [{'type': 'text', 'text': responses[q]}]
-                self.assertEqual(module.history[prev_history_count+q+len(queries)], {'role': 'assistant', 'content': resp_content})
-                self.assertEqual(module.cur_num_tokens_cache[prev_history_count+q+len(queries)], module._get_num_tokens('assistant', resp_content))
+            model_inputs.append(query)
             
-            self.assertEqual(len(module.history), prev_history_count + len(queries) * 2)
-            self.assertEqual(len(module.cur_num_tokens_cache), prev_history_count + len(queries) * 2)
-            
-            prev_history_count += len(queries) * 2
+        module._execute_batch_job = MagicMock(return_value=(mock_responses[:], 'batchid123'))
+        responses, batch_job_id, input_tokens = module.batch_infer_step(model_inputs, system_prompts, retrieve_and_return_results=True)
+        self.assertEqual(batch_job_id, 'batchid123')
+        self.assertEqual(responses, mock_responses)
+        total_input_tokens = 0
+        for q, query in enumerate(queries):
+            total_input_tokens += module._get_num_tokens(
+                'user',
+                 module.history[q][0]['content'], 
+                [(obj[1].shape[0], obj[1].shape[1]) for obj in query if obj[0] == 'image']
+            )
+        self.assertEqual(input_tokens, total_input_tokens)
+
+        for q, query in enumerate(queries):
+            self.assertEqual(responses[q], f"This is a response {q}.")
+            self.assertEqual(module.history[q][1], {'role': 'assistant', 'content': [{'type': 'text', 'text': responses[q]}]})
+            self.assertEqual(module.history[q][0]['role'], 'user')
+            self.assertTrue(isinstance(module.history[q][0]['content'], list))
+
+            for o, obj in enumerate(query):
+                if obj[0] == 'text':
+                    self.assertEqual(module.history[q][0]['content'][o], {'type': 'text', 'text': obj[1]})
+                elif obj[0] == 'image':
+                    self.assertEqual(module.history[q][0]['content'][o]['type'], 'image_url')
+                    self.assertTrue(isinstance(module.history[q][0]['content'][o]['image_url']['url'], str))
+                    self.assertTrue(module.history[q][0]['content'][o]['image_url']['url'].startswith('data:image/png;base64,'))
+
+            self.assertEqual(module.cur_num_tokens_cache[q][0], module._get_num_tokens(
+                'user',
+                 module.history[q][0]['content'], 
+                [(obj[1].shape[0], obj[1].shape[1]) for obj in query if obj[0] == 'image']
+            ))
+            self.assertEqual(module.cur_num_tokens_cache[q][1], module._get_num_tokens('assistant', [{'type': 'text', 'text': responses[q]}]))
+
+            self.assertEqual(len(module.history[q]), 2)
+            self.assertEqual(len(module.cur_num_tokens_cache[q]), 2)
 
     def test_invalid_inputs(self):
         model = "gpt-4o-2024-05-13"
@@ -364,15 +315,15 @@ class OpenAIModuleTest(unittest.TestCase):
 
         module.add_data('input', [('text', "This is a test message 1.")])
         module.clear_history()
-        self.assertEqual(module.history, [])
-        self.assertEqual(module.cur_num_tokens_cache, [])
+        self.assertEqual(module.history, [[]])
+        self.assertEqual(module.cur_num_tokens_cache, [[]])
 
         module.add_data('input', [('text', "This is a test message 2.")])
         module.add_data('output', [('text', "This is a test response.")])
         module.add_data('input', data=[('image', np.random.randint(256, size=(100, 200, 4)).astype(np.uint8))])
         module.clear_history()
-        self.assertEqual(module.history, [])
-        self.assertEqual(module.cur_num_tokens_cache, [])
+        self.assertEqual(module.history, [[]])
+        self.assertEqual(module.cur_num_tokens_cache, [[]])
 
     def test_get_num_image_tokens(self):
         model = "gpt-4o-2024-05-13"
@@ -442,22 +393,43 @@ class OpenAIModuleTest(unittest.TestCase):
         system_prompt = "This is a test system prompt."
         model = "gpt-4o-2024-05-13"
         module = OpenAIModule(model)
-        module.max_num_tokens = 1152
+        module.cur_num_tokens_cache = [[] for _ in range(5)]
+        for i in range(5):
+            module.max_num_tokens = 1152
+            module._get_num_tokens = MagicMock(return_value=10)
+            module.cur_num_tokens_cache[i] = [100, 100, 100, 100, 100]
+            self.assertEqual(module._find_starting_point(system_prompt, idx=i), 0)
+            module.cur_num_tokens_cache[i] = [500, 200, 300, 400]
+            self.assertEqual(module._find_starting_point(system_prompt, idx=i), 1)
+            module.cur_num_tokens_cache[i] = [57, 100, 231, 10, 490, 126]
+            self.assertEqual(module._find_starting_point(system_prompt, idx=i), 0)
+            module.cur_num_tokens_cache[i] = [68, 367, 111, 77, 132, 2, 100, 501, 92]
+            self.assertEqual(module._find_starting_point(system_prompt, idx=i), 3)
 
-        module._get_num_tokens = MagicMock(return_value=10)
-        module.cur_num_tokens_cache = [100, 100, 100, 100, 100]
-        self.assertEqual(module._find_starting_point(system_prompt), 0)
-        module.cur_num_tokens_cache = [500, 200, 300, 400]
-        self.assertEqual(module._find_starting_point(system_prompt), 1)
-        module.cur_num_tokens_cache = [57, 100, 231, 10, 490, 126]
-        self.assertEqual(module._find_starting_point(system_prompt), 0)
-        module.cur_num_tokens_cache = [68, 367, 111, 77, 132, 2, 100, 501, 92]
-        self.assertEqual(module._find_starting_point(system_prompt), 3)
+            module.max_num_tokens = 11
+            module.cur_num_tokens_cache[i] = [10, 5, 18, 24]
+            self.assertEqual(module._find_starting_point(system_prompt, idx=i), 4)
 
-        module.max_num_tokens = 11
-        module.cur_num_tokens_cache = [10, 5, 18, 24]
-        self.assertEqual(module._find_starting_point(system_prompt), 4)
-
+    def test_max_concurrent_prompts(self):
+        model = "gpt-4o-2024-05-13"
+        module = OpenAIModule(model, 3)
+        self.assertEqual(module.max_concurrent_prompts, 3)
+        module.history = [['test'], [2], [3]]
+        module.cur_num_tokens_cache = [[10], [91], [18]]
+        module.max_concurrent_prompts = 5
+        self.assertEqual(module.max_concurrent_prompts, 5)
+        self.assertEqual(len(module.history), 5)
+        self.assertEqual(len(module.cur_num_tokens_cache), 5)
+        module.max_concurrent_prompts = 2
+        self.assertEqual(module.max_concurrent_prompts, 2)
+        self.assertEqual(len(module.history), 2)
+        self.assertEqual(len(module.cur_num_tokens_cache), 2)
+        self.assertEqual(module.history[0], ['test'])
+        self.assertEqual(module.history[1], [2])
+        self.assertEqual(module.cur_num_tokens_cache[0], [10])
+        self.assertEqual(module.cur_num_tokens_cache[1], [91])
+        
+        
 
 if __name__=="__main__":
     unittest.main()


### PR DESCRIPTION
Added ability to handle batch processing (send jobs and later retrieve results) in openai_module.py 
Specifically changed how history and cache of tokens are stores to be a 2d array, where each list in the history corresponds to a prompt. so in a batch of 32 prompts, there'd would be 32 histories where previously it was 1. Similarly, in the case of single query processing, it's still a 2d array but with only 1 list in the history list and token cache.
 
Added ability to use openai_module's batch processing in vlm_module.py

Added OpenXBatchModule to openx_module.py to use the new batch capabilities
Added/modified a bunch of test cases