### PR TITLE
Built Overcooked AI dataset processor, and added overcooked_ai as a g…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/third_party/overcooked_ai"]
+	path = src/third_party/overcooked_ai
+	url = https://github.com/HumanCompatibleAI/overcooked_ai.git

--- a/src/utils/unpickle_helper.py
+++ b/src/utils/unpickle_helper.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""
+Helper script to unpickle a file with a specific pandas version and save it as CSV.
+
+This script is intended to be run in a separate virtual environment with a
+specific pandas version to handle version incompatibilities in pickle files.
+"""
+
+import argparse
+import pandas as pd
+
+def main():
+    parser = argparse.ArgumentParser(description="Unpickle a pandas DataFrame and save it as CSV.")
+    parser.add_argument("input_path", help="Path to the input pickle file.")
+    parser.add_argument("output_path", help="Path to save the output CSV file.")
+    args = parser.parse_args()
+
+    # Load the DataFrame from the old pickle file
+    data = pd.read_pickle(args.input_path)
+
+    # Save the DataFrame to a CSV file
+    data.to_csv(args.output_path, index=False)
+
+if __name__ == "__main__":
+    main()

--- a/src/utils/visualize_overcooked_data.py
+++ b/src/utils/visualize_overcooked_data.py
@@ -1,0 +1,46 @@
+import base64
+import io
+import csv
+import pygame
+
+def visualize_csv(input_path, n):
+    """
+    Visualizes the first n states from a processed CSV file.
+    """
+    pygame.init()
+
+    with open(input_path, 'r') as infile:
+        reader = csv.DictReader(infile)
+        for i, row in enumerate(reader):
+            if i >= n:
+                break
+
+            print(f"Displaying state {i+1}/{n}")
+            base64_str = row['state']
+            img_data = base64.b64decode(base64_str)
+            img_byte_arr = io.BytesIO(img_data)
+            
+            img_surface = pygame.image.load(img_byte_arr)
+            
+            screen = pygame.display.set_mode(img_surface.get_size())
+            screen.blit(img_surface, (0, 0))
+            pygame.display.flip()
+
+            running = True
+            while running:
+                for event in pygame.event.get():
+                    if event.type == pygame.QUIT:
+                        running = False
+                    if event.type == pygame.KEYDOWN:
+                        if event.key == pygame.K_q or event.key == pygame.K_ESCAPE:
+                            running = False
+            
+    pygame.quit()
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_csv", help="Path to the input CSV file.")
+    parser.add_argument("-n", type=int, default=5, help="Number of states to visualize.")
+    args = parser.parse_args()
+    visualize_csv(args.input_csv, args.n)

--- a/tst/modules/dataset_modules/test_overcooked_module.py
+++ b/tst/modules/dataset_modules/test_overcooked_module.py
@@ -1,0 +1,87 @@
+import unittest
+import os
+import sys
+from pathlib import Path
+import shutil
+import pickle
+import csv
+import base64
+
+# Add project root to sys.path
+ROOT_DIR = Path(__file__).parent.parent.parent.parent
+sys.path.append(str(ROOT_DIR))
+sys.path.append(str(ROOT_DIR / 'src' / 'third_party' / 'overcooked_ai' / 'src'))
+
+from src.v1.centralized_processor import OvercookedAIProcessor, ProcessResult
+
+class TestOvercookedAIProcessor(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test data and directories."""
+        self.test_input_dir = Path("test_data_temp")
+        self.test_output_dir = Path("test_output_temp")
+        self.overcooked_input_dir = self.test_input_dir / "overcooked_ai"
+        self.overcooked_output_dir = self.test_output_dir / "overcooked_ai"
+
+        # Create directories
+        self.overcooked_input_dir.mkdir(parents=True, exist_ok=True)
+        self.overcooked_output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create dummy data
+        self.dummy_data = [{'state': '{"players": [{"position": [1, 1], "orientation": [0, -1], "held_object": null}], "objects": [], "bonus_orders": [], "all_orders": [], "timestep": 0}', 'layout': '["X", " ", "X"], ["X", "P", "X"], ["X", " ", "X"]'}]
+        self.dummy_pickle_path = self.overcooked_input_dir / 'dummy_data.pickle'
+        with open(self.dummy_pickle_path, 'wb') as picklefile:
+            pickle.dump(self.dummy_data, picklefile)
+
+    def tearDown(self):
+        """Clean up test data and directories."""
+        if self.test_input_dir.exists():
+            shutil.rmtree(self.test_input_dir)
+        if self.test_output_dir.exists():
+            shutil.rmtree(self.test_output_dir)
+
+    def test_process_success(self):
+        """Test successful processing of an Overcooked AI dataset."""
+        processor = OvercookedAIProcessor("overcooked_ai", self.test_input_dir, self.test_output_dir)
+        result = processor.process()
+
+        self.assertTrue(result.success)
+        self.assertIsInstance(result, ProcessResult)
+        self.assertEqual(result.name, "overcooked_ai")
+        self.assertGreater(result.files_processed, 0)
+        self.assertIsNone(result.error)
+
+        # Check for output files
+        output_prefix = self.overcooked_output_dir / "test" / "dummy_data"
+        processed_csv_path = output_prefix.with_suffix('.csv')
+        processed_pickle_path = output_prefix.with_suffix('.pickle')
+        self.assertTrue(processed_csv_path.exists())
+        self.assertTrue(processed_pickle_path.exists())
+
+        # Verify content of processed csv
+        with open(processed_csv_path, 'r') as f:
+            reader = csv.DictReader(f)
+            processed_data = list(reader)
+            self.assertEqual(len(processed_data), 1)
+            # Check if state is a valid base64 string
+            try:
+                base64.b64decode(processed_data[0]['state'])
+            except Exception as e:
+                self.fail(f"State is not a valid base64 string: {e}")
+
+    def test_process_failure_no_input_file(self):
+        """Test processing failure when no input file is found."""
+        # Remove the dummy file
+        os.remove(self.dummy_pickle_path)
+
+        processor = OvercookedAIProcessor("overcooked_ai", self.test_input_dir, self.test_output_dir)
+        result = processor.process()
+
+        self.assertFalse(result.success)
+        self.assertIsInstance(result, ProcessResult)
+        self.assertEqual(result.name, "overcooked_ai")
+        self.assertIsNotNone(result.error)
+        self.assertIn("No pickle or CSV file found", result.error)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Built Overcooked AI dataset processor, and added overcooked_ai as a git submodule to check it out. The dataset 
processor supports both the .csv and .pickle files of the (cleaned!) overcooked datasets. It then goes through and transforms the  game State to an image, and recreates the dataset. Additionally for the pickle files, it recreates the pickle file using  our version of pandas for ease of processing in the rest of the repository.

File changes:
Updated the `OvercookedAIProcessor` class in `centralized_processor.py`. This processor processor converts symbolic game states from the dataset into base64-encoded visual observations (images) using the `overcooked_ai_py` library. A core challenge is that the Overcooked AI dataset contains pickle files generated with an older, incompatible version of pandas.  As such we've added a fallback mechanism that creates a temporary virtual environment with the older pandas and transforms the pickle file into a CSV for easier processing. This is a temporary solution as eventually pandas 1.5 will fall fully out of pip. There is a utility file added in src/utils/unpickle_helper.py, that handles this conversion Additionally there is a script at src/utils/visualize_overcooked_data.py that can quickly render the csv file images so that we can do a spot check of the visualized environments.

Finally there is a new test file in tst/test_overcooked_module.py, which has a basic test of the processor just for future proofing and system analysis.


This is for Issue #616. 