### PR TITLE
[608] Create VQA metrics module

### DIFF
--- a/src/eval_harness/scoring/vqa_metrics.py
+++ b/src/eval_harness/scoring/vqa_metrics.py
@@ -1,0 +1,123 @@
+from typing import Dict, Any, List
+import numpy as np
+import re
+from sentence_transformers import SentenceTransformer, util
+
+
+def _validate_text_output(output: Any) -> bool:
+    """Validate that output is a valid text string."""
+    if output is None:
+        return False
+    if isinstance(output, str) and len(output.strip()) > 0:
+        return True
+    return False
+
+
+def _normalize_text(text: str) -> str:
+    """Normalize text for comparison by removing punctuation and extra spaces."""
+    if not isinstance(text, str):
+        return ""
+    # Remove punctuation and convert to lowercase
+    text = re.sub(r'[^\w\s]', '', text.lower())
+    # Remove extra whitespace
+    text = ' '.join(text.split())
+    return text
+
+
+class VQAMetricsCalculator:
+    """
+    Calculator for VQA metrics.
+    
+    Takes text predictions and ground truth answers, calculates similarity and accuracy metrics.
+    """
+    
+    def __init__(self, similarity_model_name: str = "all-MiniLM-L6-v2"):
+        """
+        Initialize with a sentence transformer model for similarity calculations.
+        
+        Args:
+            similarity_model_name: Name of the sentence transformer model to use
+        """
+        self.similarity_model = SentenceTransformer(similarity_model_name)
+    
+    def calculate_metrics(self, predictions: List[str], ground_truth_answers: List[str]) -> Dict[str, Any]:
+        """
+        Calculate metrics for text predictions vs ground truth answers.
+        
+        Args:
+            predictions: List of model text predictions
+            ground_truth_answers: List of ground truth text answers
+            
+        Returns:
+            Dictionary containing calculated metrics
+        """
+        exact_matches = []
+        similarity_scores = []
+        total_invalid_preds = 0
+        
+        for i, pred in enumerate(predictions):
+            if _validate_text_output(pred):
+                # Normalize both prediction and ground truth for fair comparison
+                normalized_pred = _normalize_text(pred)
+                normalized_gt = _normalize_text(ground_truth_answers[i])
+                
+                # Calculate exact match
+                exact_match = 1.0 if normalized_pred == normalized_gt else 0.0
+                exact_matches.append(exact_match)
+                
+                # Calculate similarity score using sentence embeddings
+                try:
+                    emb1 = self.similarity_model.encode(pred, convert_to_tensor=True)
+                    emb2 = self.similarity_model.encode(ground_truth_answers[i], convert_to_tensor=True)
+                    similarity = util.cos_sim(emb1, emb2).item()
+                    similarity_scores.append(similarity)
+                except Exception as e:
+                    # If similarity calculation fails, assign 0.0
+                    print(f"Warning: Similarity calculation failed for prediction {i}: {e}")
+                    similarity_scores.append(0.0)
+            else:
+                # Invalid output - assign worst possible scores
+                exact_matches.append(0.0)
+                similarity_scores.append(0.0)
+                total_invalid_preds += 1
+        
+        return self._calculate_final_metrics(exact_matches, similarity_scores, total_invalid_preds)
+    
+    def _calculate_final_metrics(self, exact_matches: List[float], similarity_scores: List[float], total_invalid_preds: int) -> Dict[str, Any]:
+        """Calculate comprehensive final metrics for QA evaluation."""
+        result = {}
+        
+        # Calculate accuracy metrics
+        total_samples = len(exact_matches)
+        exact_match_accuracy = sum(exact_matches) / total_samples if total_samples > 0 else 0.0
+        
+        # Calculate similarity metrics
+        avg_similarity_score = sum(similarity_scores) / total_samples if total_samples > 0 else 0.0
+        max_similarity_score = max(similarity_scores) if similarity_scores else 0.0
+        min_similarity_score = min(similarity_scores) if similarity_scores else 0.0
+        
+        # Calculate additional statistics
+        similarity_std = np.std(similarity_scores) if similarity_scores else 0.0
+        
+        # Calculate percentage of high similarity matches (threshold-based)
+        high_similarity_threshold = 0.8
+        high_similarity_count = sum(1 for score in similarity_scores if score >= high_similarity_threshold)
+        high_similarity_percentage = (high_similarity_count / total_samples * 100) if total_samples > 0 else 0.0
+        
+        # Calculate invalid prediction percentage
+        invalid_percentage = (total_invalid_preds / total_samples * 100) if total_samples > 0 else 0.0
+        
+        result.update({
+            'exact_match_accuracy': exact_match_accuracy,
+            'avg_similarity_score': avg_similarity_score,
+            'max_similarity_score': max_similarity_score,
+            'min_similarity_score': min_similarity_score,
+            'similarity_std': similarity_std,
+            'high_similarity_percentage': high_similarity_percentage,
+            'high_similarity_threshold': high_similarity_threshold,
+            'total_samples': total_samples,
+            'total_invalid_preds': total_invalid_preds,
+            'invalid_percentage': invalid_percentage,
+        })
+        
+        return result

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ ale-py==0.8.1
 annotated-types==0.7.0
 anyio==4.4.0
 arch==7.0.0
-#array_record==0.5.1
+array_record==0.8.1
 asttokens==2.4.1
 astunparse==1.6.3
 async-timeout==4.0.3
@@ -77,7 +77,7 @@ jedi==0.19.1
 Jinja2==3.1.4
 jiter==0.5.0
 joblib==1.4.2
-keras==3.4.1
+keras==3.11.3
 kiwisolver==1.4.5
 labmaze==1.0.6
 libclang==18.1.1
@@ -91,9 +91,10 @@ matplotlib-inline==0.1.7
 mdurl==0.1.2
 metaworld @ git+https://github.com/qgallouedec/Metaworld@50d3255ffb4bfe14eff0200ea41d50cc08576cb3
 minigrid==2.3.1
-ml-dtypes==0.3.2
+ml_dtypes==0.5.3
 monotonic==1.6
 mpmath==1.3.0
+mujoco==2.3.7
 mujoco-py==2.1.2.14
 multidict==6.0.5
 multiprocess==0.70.16
@@ -101,7 +102,7 @@ mushroom-rl==1.10.1
 mypy-extensions==1.0.0
 namex==0.0.8
 networkx==3.3
-nltk<=3.8.2
+nltk==3.8.1
 numpy==1.26.4
 nvidia-cublas-cu12==12.1.3.1
 nvidia-cuda-cupti-cu12==12.1.105
@@ -172,14 +173,15 @@ sniffio==1.3.1
 stack-data==0.6.3
 statsmodels==0.14.2
 sympy==1.12.1
-tensorboard==2.16.2
+tensorboard==2.19.0
 tensorboard-data-server==0.7.2
 tensordict==0.4.0
-tensorflow==2.16.2
+tensorflow==2.19.1
 tensorflow-datasets==4.9.6
 tensorflow-io-gcs-filesystem==0.37.1
 tensorflow-metadata==1.15.0
 termcolor==2.4.0
+tf_keras==2.19.0
 threadpoolctl==3.5.0
 tiktoken==0.7.0
 timm==1.0.8

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -6,7 +6,7 @@ ale-py==0.8.1
 annotated-types==0.7.0
 anyio==4.4.0
 arch==7.0.0
-array_record==0.8.1
+#array_record==0.5.1
 asttokens==2.4.1
 astunparse==1.6.3
 async-timeout==4.0.3
@@ -77,7 +77,7 @@ jedi==0.19.1
 Jinja2==3.1.4
 jiter==0.5.0
 joblib==1.4.2
-keras==3.11.3
+keras==3.4.1
 kiwisolver==1.4.5
 labmaze==1.0.6
 libclang==18.1.1
@@ -91,10 +91,9 @@ matplotlib-inline==0.1.7
 mdurl==0.1.2
 metaworld @ git+https://github.com/qgallouedec/Metaworld@50d3255ffb4bfe14eff0200ea41d50cc08576cb3
 minigrid==2.3.1
-ml_dtypes==0.5.3
+ml-dtypes==0.3.2
 monotonic==1.6
 mpmath==1.3.0
-mujoco==2.3.7
 mujoco-py==2.1.2.14
 multidict==6.0.5
 multiprocess==0.70.16
@@ -102,7 +101,7 @@ mushroom-rl==1.10.1
 mypy-extensions==1.0.0
 namex==0.0.8
 networkx==3.3
-nltk==3.8.1
+nltk<=3.8.2
 numpy==1.26.4
 nvidia-cublas-cu12==12.1.3.1
 nvidia-cuda-cupti-cu12==12.1.105
@@ -173,15 +172,15 @@ sniffio==1.3.1
 stack-data==0.6.3
 statsmodels==0.14.2
 sympy==1.12.1
-tensorboard==2.19.0
+tensorboard==2.16.2
 tensorboard-data-server==0.7.2
 tensordict==0.4.0
-tensorflow==2.19.1
+tensorflow==2.16.2
 tensorflow-datasets==4.9.6
 tensorflow-io-gcs-filesystem==0.37.1
 tensorflow-metadata==1.15.0
 termcolor==2.4.0
-tf_keras==2.19.0
+tf_keras==2.16.0
 threadpoolctl==3.5.0
 tiktoken==0.7.0
 timm==1.0.8

--- a/tst/metrics_calculators/test_vqa_metrics.py
+++ b/tst/metrics_calculators/test_vqa_metrics.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import math
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(ROOT_DIR)
+
+import numpy as np
+import pytest
+
+from src.eval_harness.scoring.vqa_metrics import (
+    _validate_text_output,
+    _normalize_text,
+    VQAMetricsCalculator,
+)
+import src.eval_harness.scoring.vqa_metrics as vqa_metrics_module
+
+
+def test_validate_text_output():
+    assert _validate_text_output("Hello")
+    assert _validate_text_output("  world  ")
+    assert not _validate_text_output("")
+    assert not _validate_text_output("   ")
+    assert not _validate_text_output(None)
+    assert not _validate_text_output(123)
+
+
+def test_normalize_text():
+    assert _normalize_text("Hello, World!") == "hello world"
+    assert _normalize_text("  Multiple    spaces\tand\nlines  ") == "multiple spaces and lines"
+    assert _normalize_text("Punctuation: should; be-removed?") == "punctuation should beremoved"
+    assert _normalize_text(123) == ""
+
+
+def test_vqa_metrics_calculator_with_mocked_similarity(monkeypatch):
+    class FakeModel:
+        def encode(self, text, convert_to_tensor=True):
+            return text
+
+    class DummyScore:
+        def __init__(self, value):
+            self._value = float(value)
+
+        def item(self):
+            return self._value
+
+    def fake_cos_sim(a, b):
+        return DummyScore(1.0 if a == b else 0.25)
+
+    monkeypatch.setattr(vqa_metrics_module.util, "cos_sim", fake_cos_sim)
+    monkeypatch.setattr(vqa_metrics_module, "SentenceTransformer", lambda name: FakeModel())
+
+    calc = VQAMetricsCalculator()
+
+    predictions = [
+        "A cat on a mat",
+        "a CAT on a mat!", 
+        "A cat outside",
+        None,                # invalid
+        "   ",              # invalid
+    ]
+
+    gts = [
+        "A cat on a mat",
+        "a CAT on a mat!",
+        "A cat on a mat",
+        "Does not matter",
+        "Also irrelevant",
+    ]
+
+    metrics = calc.calculate_metrics(predictions, gts)
+
+    # exact matches: first two are matches -> 2/5
+    assert math.isclose(metrics["exact_match_accuracy"], 2 / 5)
+
+    # similarity scores per pair (using fake_cos_sim):
+    # 1) equal? True -> 1.0
+    # 2) equal? True -> 1.0
+    # 3) equal? False -> 0.25
+    # 4) invalid -> 0.0
+    # 5) invalid -> 0.0
+    expected_sims = [1.0, 1.0, 0.25, 0.0, 0.0]
+    assert math.isclose(metrics["avg_similarity_score"], sum(expected_sims) / 5)
+    assert math.isclose(metrics["max_similarity_score"], max(expected_sims))
+    assert math.isclose(metrics["min_similarity_score"], min(expected_sims))
+    assert math.isclose(metrics["similarity_std"], float(np.std(expected_sims)))
+
+    # high similarity threshold is 0.8 in implementation
+    assert metrics["high_similarity_threshold"] == 0.8
+    high_sim_count = sum(1 for s in expected_sims if s >= 0.8)
+    assert math.isclose(metrics["high_similarity_percentage"], high_sim_count / 5 * 100.0)
+
+    # invalid predictions
+    assert metrics["total_samples"] == 5
+    assert metrics["total_invalid_preds"] == 2
+    assert math.isclose(metrics["invalid_percentage"], 2 / 5 * 100.0)
+
+    print(metrics)
+    
+if __name__ == "__main__":
+    pytest.main(['-s', __file__])
+
+    


### PR DESCRIPTION
- Changed requirements file to include tf-keras so sentence_transformers can be imported (needed for genesis robovqa as well afaik)
- The metrics added includes min/max/std similarity scores and also a metric for the number of "high similarity" scores (high_similarity_percentage). If we think these are useful, we can update the GPT vqa modules to include these as well