### PR TITLE
Single input inference genesis OpenX

### DIFF
--- a/scripts/eval_vlm/run_eval_vlm.py
+++ b/scripts/eval_vlm/run_eval_vlm.py
@@ -21,6 +21,7 @@ if __name__=="__main__":
     parser.add_argument('--batch_size', type=int, default=1, help="The batch size used for evaluation.")
     parser.add_argument('--k_shots', type=int, default=0, help="Setting how many few-shots examples should be used.")
     parser.add_argument('--dataset_name', type=str, required=True, help="The name of the dataset to evaluate.")
+    parser.add_argument('--disk_root_dir', type=str, required=True, help="The root directory of the translated data.")
     args = parser.parse_args()
     
     if args.batch_process:
@@ -56,10 +57,10 @@ if __name__=="__main__":
     # TODO: More branches will be added during the implementation.
     dataset_module = None
     if dataset_family == 'procgen' and args.batch_process:
-        dataset_module = ProcGenBatchModule('.', modality, source, model, 1, 0)
+        dataset_module = ProcGenBatchModule(args.disk_root_dir, modality, source, model, 1, 0)
     elif dataset_family == 'openx' and args.batch_process:
-        dataset_module = OpenXBatchModule('.', modality, source, model, 1, 0)
+        dataset_module = OpenXBatchModule(args.disk_root_dir, modality, source, model, 1, 0)
     elif dataset_family == 'openx' and not args.batch_process:
-        dataset_module = OpenXModule('.', modality, source, model, args.dataset_name, 1, 0)
+        dataset_module = OpenXModule(args.disk_root_dir, modality, source, model, args.dataset_name, 1, 0)
     
     dataset_module.run_eval(os.path.abspath(args.results_path), batch_info_dict)

--- a/scripts/eval_vlm/run_eval_vlm.py
+++ b/scripts/eval_vlm/run_eval_vlm.py
@@ -44,17 +44,19 @@ if __name__=="__main__":
         dataset_family = batch_info['dataset_family'].item()
         model = batch_info['model'].item()
 
+        # Setting the configurations of the current evaluation job.
+        modality, source = config['models'][model]
+
+         # Setting the extra information depending on the model.
+        if source == 'openai':
+            os.environ["OPENAI_API_KEY"] = input("Enter the OpenAI API key: ")
+
         assert dataset_family in config['datasets'].keys(), f"Specify the correct dataset name supported:\n{list(config['datasets'].keys())}"
         assert model in config["models"].keys(), f"Specify the correct model index supported.\n{list(config['models'].keys())}"
     
+    
 
-
-    # Setting the configurations of the current evaluation job.
-    modality, source = config['models'][model]
-
-    # Setting the extra information depending on the model.
-    if source == 'openai':
-        os.environ["OPENAI_API_KEY"] = input("Enter the OpenAI API key: ")
+   
         
     # TODO: More branches will be added during the implementation.
     dataset_module = None
@@ -63,6 +65,7 @@ if __name__=="__main__":
     elif dataset_family == 'openx' and args.batch_process:
         dataset_module = OpenXBatchModule(args.disk_root_dir, modality, source, model, 1, 0)
     elif dataset_family == 'openx' and not args.batch_process:
-        dataset_module = OpenXModule(args.disk_root_dir, modality, source, model, args.dataset_name, 1, 0)
+        os.environ["OPENAI_API_KEY"] = input("Enter the OpenAI API key: ")
+        dataset_module = OpenXModule(args.disk_root_dir, 'vlm', 'openai', args.model, args.dataset_name, 1, 0)
     
     dataset_module.run_eval(os.path.abspath(args.results_path), batch_info_dict)

--- a/scripts/eval_vlm/run_eval_vlm.py
+++ b/scripts/eval_vlm/run_eval_vlm.py
@@ -45,6 +45,9 @@ if __name__=="__main__":
         dataset_family = batch_info['dataset_family'].item()
         model = batch_info['model'].item()
 
+        assert dataset_family in config['datasets'].keys(), f"Specify the correct dataset name supported:\n{list(config['datasets'].keys())}"
+        assert model in config["models"].keys(), f"Specify the correct model index supported.\n{list(config['models'].keys())}"
+
         # Setting the configurations of the current evaluation job.
         modality, source = config['models'][model]
 
@@ -52,8 +55,6 @@ if __name__=="__main__":
         if source == 'openai':
             os.environ["OPENAI_API_KEY"] = input("Enter the OpenAI API key: ")
 
-        assert dataset_family in config['datasets'].keys(), f"Specify the correct dataset name supported:\n{list(config['datasets'].keys())}"
-        assert model in config["models"].keys(), f"Specify the correct model index supported.\n{list(config['models'].keys())}"
 
         # TODO: More branches will be added during the implementation.
         dataset_module = None

--- a/scripts/eval_vlm/run_eval_vlm.py
+++ b/scripts/eval_vlm/run_eval_vlm.py
@@ -23,6 +23,13 @@ if __name__=="__main__":
     parser.add_argument('--dataset_name', type=str, required=True, help="The name of the dataset to evaluate.")
     parser.add_argument('--disk_root_dir', type=str, required=True, help="The root directory of the translated data.")
     args = parser.parse_args()
+
+    # Argument validation.
+    # TODO: Update config.json everytime a new dataset or model is added into the new version.
+    config_path = os.path.join(ROOT_DIR, 'src', 'config.json')
+    assert os.path.exists(config_path), f"The config file does not exist: {config_path}"
+    with open(config_path, 'r') as f:
+        config = json.load(f)
     
     if args.batch_process:
         assert args.batch_job_info_path is not None, "The batch job information path is required when running batch processing."
@@ -36,16 +43,11 @@ if __name__=="__main__":
 
         dataset_family = batch_info['dataset_family'].item()
         model = batch_info['model'].item()
-    
-    # Argument validation.
-    # TODO: Update config.json everytime a new dataset or model is added into the new version.
-    config_path = os.path.join(ROOT_DIR, 'src', 'config.json')
-    assert os.path.exists(config_path), f"The config file does not exist: {config_path}"
-    with open(config_path, 'r') as f:
-        config = json.load(f)
 
-    assert dataset_family in config['datasets'].keys(), f"Specify the correct dataset name supported:\n{list(config['datasets'].keys())}"
-    assert model in config["models"].keys(), f"Specify the correct model index supported.\n{list(config['models'].keys())}"
+        assert dataset_family in config['datasets'].keys(), f"Specify the correct dataset name supported:\n{list(config['datasets'].keys())}"
+        assert model in config["models"].keys(), f"Specify the correct model index supported.\n{list(config['models'].keys())}"
+    
+
 
     # Setting the configurations of the current evaluation job.
     modality, source = config['models'][model]

--- a/src/modules/dataset_modules/base_dataset_module.py
+++ b/src/modules/dataset_modules/base_dataset_module.py
@@ -77,14 +77,14 @@ class DatasetModule(ABC):
         return res.reshape(list(targets.shape)+[nb_classes])
 
     # Main evaluation function.
-    def run_eval(self) -> None:
+    def run_eval(self, results_path: str) -> None:
         # Since OpenX consists of multiple datasets, a modality module should be initialized per every evaluation step for each dataset.
 
         total_results = {}
         for dataset in self.datasets:
             
-            if os.path.exists('<path to results>'):
-                with open('<path to results>', 'r') as f:
+            if os.path.exists(results_path):
+                with open(results_path, 'r') as f:
                     completed_datasets = json.load(f)
             
                 if dataset in completed_datasets:
@@ -94,9 +94,9 @@ class DatasetModule(ABC):
             result = self._run_eval_dataset(dataset)
             total_results[dataset] = result
             
-            if os.path.exists('<path to results>'):
+            if os.path.exists(results_path):
                 # If it exists, load the existing data
-                with open('<path to results>', 'r') as f:
+                with open(results_path, 'r') as f:
                     existing_results = json.load(f)
                 # Append new data to existing data
                 existing_results.update(total_results)
@@ -105,7 +105,7 @@ class DatasetModule(ABC):
                 existing_results = total_results
 
             # Write the updated or new results to the file
-            with open('<path to results>', 'w') as f:
+            with open(results_path, 'w') as f:
                 json.dump(existing_results, f, indent=4, default=lambda x: x.tolist() if isinstance(x, np.ndarray) else x)
             self.action_stats = None
 

--- a/src/modules/dataset_modules/base_dataset_module.py
+++ b/src/modules/dataset_modules/base_dataset_module.py
@@ -13,11 +13,12 @@ import os
 import warnings
 
 class DatasetModule(ABC):
-    def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, batch_size: int = 1, k_shots: int = 0) -> None:
+    def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, dataset_name: str, batch_size: int = 1, k_shots: int = 0) -> None:
         self._definitions_class = None
         self.get_dataloader_fn = None 
         self.dataset_family = None
         self.format_instruction_prompt_fn = None
+        self.dataset_name = dataset_name
 
         self.disk_root_dir = disk_root_dir
         self.batch_size = batch_size
@@ -43,10 +44,13 @@ class DatasetModule(ABC):
     @property
     def datasets(self):
         if len(self._datasets) == 0:
-            for dataset in list(self.descriptions.keys()):
-                tfds_shards = self._find_shards(dataset)
-                if len(tfds_shards) != 0:
-                    self._datasets.append(dataset)
+            if self.dataset_name is not None:
+                self._datasets.append(self.dataset_name)
+            else:
+                for dataset in list(self.descriptions.keys()):
+                    tfds_shards = self._find_shards(dataset)
+                    if len(tfds_shards) != 0:
+                        self._datasets.append(dataset)
         return self._datasets
         
     @property

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -97,7 +97,7 @@ def _calculate_final_metrics(timestep_mses, timestep_maes, action_success):
 # Finding the translated TFDS shards.
 def _find_shards(dataset: str, disk_root_dir: str) -> list[str]:
     try:
-        dataset_dir = glob(f"/mnt/disks/mount_dir/MultiNet/src/v1/processed/{dataset}/test/")[0]
+        dataset_dir = glob(f"{disk_root_dir}/{dataset}/test/")[0]
         shard_files = glob(f"{dataset_dir}/translated_shard_*")
         tfds_shards = sorted(shard_files, key=lambda x: int(x.split('_')[-1]))
         return tfds_shards

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -113,6 +113,7 @@ class OpenXModule(DatasetModule):
         self.dataset_family = 'openx'
         self.dataset_name = dataset_name
         self.format_instruction_prompt_fn = format_instruction_prompt  
+        self.batch_size = batch_size
     
     def _find_shards(self, dataset: str) -> list[str]:
         return _find_shards(dataset, self.disk_root_dir)

--- a/src/modules/dataset_modules/openx_module.py
+++ b/src/modules/dataset_modules/openx_module.py
@@ -106,11 +106,12 @@ def _find_shards(dataset: str, disk_root_dir: str) -> list[str]:
         return []
     
 class OpenXModule(DatasetModule):
-    def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, batch_size: int = 1, k_shots: int = 0) -> None:
+    def __init__(self, disk_root_dir: str, modality: str, source: str, model: str, dataset_name: str, batch_size: int = 1, k_shots: int = 0) -> None:
         super().__init__(disk_root_dir, modality, source, model, batch_size, k_shots)
         self._definitions_class = OpenXDefinitions
         self.get_dataloader_fn = get_openx_dataloader
         self.dataset_family = 'openx'
+        self.dataset_name = dataset_name
         self.format_instruction_prompt_fn = format_instruction_prompt  
     
     def _find_shards(self, dataset: str) -> list[str]:


### PR DESCRIPTION
Changes to the run_eval_vlm.py, base_dataset_module.py, and openx_module.py to enable single input inference.
For v1 we plan to profile the gpt-5-chat-latest model, which is a SoTA, recent VLM that is also used in ChatGPT. The models that have reasoning integrated such as gpt-5 produce empty strings as outputs when tested on robotics datasets, but gpt-5-chat-latest gives valid results. However, this model does not have a batch inference API publicly available. Thus this PR is to enable single input inference for GenESIS, specifically for OpenX