### PR TITLE
Handling action dictionaries in OpenX

### DIFF
--- a/src/data_utils/openx_dataloader.py
+++ b/src/data_utils/openx_dataloader.py
@@ -120,7 +120,13 @@ class OpenXDataset(Dataset):
                 text_answer = elem['observation']['raw_text_answer'].numpy().decode('utf-8')
 
             if self.dataset_name == "robot_vqa":
-                text_observation_multi_embodiment = f"Task and Context: {text_observation.split(' Q: ',1)[0].strip()}\n Question: {text_observation.split(' Q: ',1)[1].strip()}"
+                parts = text_observation.split('Q:', 1)
+                if len(parts) == 1:
+                    text_observation_multi_embodiment = text_observation
+                elif len(parts) == 2 and text_observation.startswith("Q:"):
+                    text_observation_multi_embodiment = f"Question: {parts[1].strip()}"
+                else:
+                    text_observation_multi_embodiment = f"Task and Context: {parts[0].strip()}\n Question: {parts[1].strip()}"
 
             # Extract relevant features from the example
             step_data = {
@@ -170,6 +176,7 @@ class OpenXDataset(Dataset):
                         'min': np.full(self.action_tensor_size, np.inf),
                         'max': np.full(self.action_tensor_size, -np.inf),
                         'sum': np.zeros(self.action_tensor_size),
+                        'sum_of_squares': np.zeros(self.action_tensor_size),
                         'count': 0
                     }
                 self._action_stats['min'] = np.minimum(self._action_stats['min'], concatenated_action_float)
@@ -181,8 +188,36 @@ class OpenXDataset(Dataset):
     def action_stats(self):
         if self._action_stats is None:
             self._populate_action_stats()
+            # Check if _populate_action_stats actually populated data
+            if self._action_stats is None:
+                # If no action data was found, return a default structure
+                return {
+                    'min': [],
+                    'max': [],
+                    'sum': [],
+                    'mean': [],
+                    'std': [],
+                    'count': 0,
+                    'size': (0,)
+                }
+
             self._action_stats['mean'] = self._action_stats['sum'] / self._action_stats['count']
+            # Compute variance using E[X²] - E[X]²
+            mean_of_squares = self._action_stats['sum_of_squares'] / self._action_stats['count']
+            variance = mean_of_squares - (self._action_stats['mean'] ** 2)
+            self._action_stats['std'] = np.sqrt(variance + 1e-8)
             self._action_stats['size'] = self.action_tensor_size
+
+            # Convert numpy arrays to lists for JSON serialization
+            for key in ['min', 'max', 'sum', 'mean', 'std']:
+                if key in self._action_stats and hasattr(self._action_stats[key], 'tolist'):
+                    self._action_stats[key] = self._action_stats[key].tolist()
+
+            # Convert action_tensor_size tuple to list for JSON compatibility
+            if hasattr(self.action_tensor_size, '__iter__'):
+                self._action_stats['size'] = list(self.action_tensor_size)
+            else:
+                self._action_stats['size'] = [self.action_tensor_size] if self.action_tensor_size is not None else []
         return self._action_stats
         
 

--- a/src/data_utils/openx_dataloader.py
+++ b/src/data_utils/openx_dataloader.py
@@ -35,7 +35,12 @@ class OpenXDataset(Dataset):
                 elem['reward'] = None                
             concatenated_action_float = elem['action']
             float_action_tensors = []
+            # Store the original action dictionary if it's a dict, otherwise None
+            action_dict = None
             if isinstance(elem['action'], dict):
+                # Store the original action dictionary
+                action_dict = {key: tensor.numpy() for key, tensor in elem['action'].items()}
+                
                 elem['action'] = dict(sorted(elem['action'].items()))
                 #Input processing
                 for key, tensor in elem['action'].items():
@@ -115,19 +120,14 @@ class OpenXDataset(Dataset):
                 text_answer = elem['observation']['raw_text_answer'].numpy().decode('utf-8')
 
             if self.dataset_name == "robot_vqa":
-                parts = text_observation.split('Q:', 1)
-                if len(parts) == 1:
-                    text_observation_multi_embodiment = text_observation
-                elif len(parts) == 2 and text_observation.startswith("Q:"):
-                    text_observation_multi_embodiment = f"Question: {parts[1].strip()}"
-                else:
-                    text_observation_multi_embodiment = f"Task and Context: {parts[0].strip()}\n Question: {parts[1].strip()}"
+                text_observation_multi_embodiment = f"Task and Context: {text_observation.split(' Q: ',1)[0].strip()}\n Question: {text_observation.split(' Q: ',1)[1].strip()}"
 
             # Extract relevant features from the example
             step_data = {
                 'text_observation': text_observation if self.dataset_name != "robot_vqa" else text_observation_multi_embodiment,
                 'image_observation': image_observation,
                 'action': concatenated_action_float,
+                'action_dict': action_dict,
                 'reward': elem['reward'].numpy() if self.dataset_name != "robot_vqa" else elem['reward'],
                 'is_last': elem['is_last'].numpy(),
                 'text_answer': text_answer
@@ -170,50 +170,19 @@ class OpenXDataset(Dataset):
                         'min': np.full(self.action_tensor_size, np.inf),
                         'max': np.full(self.action_tensor_size, -np.inf),
                         'sum': np.zeros(self.action_tensor_size),
-                        'sum_of_squares': np.zeros(self.action_tensor_size),
                         'count': 0
                     }
                 self._action_stats['min'] = np.minimum(self._action_stats['min'], concatenated_action_float)
                 self._action_stats['max'] = np.maximum(self._action_stats['max'], concatenated_action_float)
                 self._action_stats['sum'] += concatenated_action_float
-                self._action_stats['sum_of_squares'] += concatenated_action_float ** 2
                 self._action_stats['count'] += 1
     
     @property
     def action_stats(self):
         if self._action_stats is None:
             self._populate_action_stats()
-            # Check if _populate_action_stats actually populated data
-            if self._action_stats is None:
-                # If no action data was found, return a default structure
-                return {
-                    'min': [],
-                    'max': [],
-                    'sum': [],
-                    'mean': [],
-                    'std': [],
-                    'count': 0,
-                    'size': (0,)
-                }
-            
             self._action_stats['mean'] = self._action_stats['sum'] / self._action_stats['count']
-            # Compute variance using E[X²] - E[X]²
-            mean_of_squares = self._action_stats['sum_of_squares'] / self._action_stats['count']
-            variance = mean_of_squares - (self._action_stats['mean'] ** 2)
-            self._action_stats['std'] = np.sqrt(variance + 1e-8)
             self._action_stats['size'] = self.action_tensor_size
-            
-            # Convert numpy arrays to lists for JSON serialization
-            for key in ['min', 'max', 'sum', 'mean', 'std']:
-                if key in self._action_stats and hasattr(self._action_stats[key], 'tolist'):
-                    self._action_stats[key] = self._action_stats[key].tolist()
-            
-            # Convert action_tensor_size tuple to list for JSON compatibility
-            if hasattr(self.action_tensor_size, '__iter__'):
-                self._action_stats['size'] = list(self.action_tensor_size)
-            else:
-                self._action_stats['size'] = [self.action_tensor_size] if self.action_tensor_size is not None else []
-                    
         return self._action_stats
         
 
@@ -260,6 +229,7 @@ class OpenXDataset(Dataset):
         image_observation = []
         etc_observations = {}
         concatenated_action_float = []
+        action_dict = []
         reward = []
         is_last = []
         text_answer = []
@@ -271,6 +241,8 @@ class OpenXDataset(Dataset):
             timestep.pop('image_observation')
             concatenated_action_float.append(timestep['action'])
             timestep.pop('action')
+            action_dict.append(timestep['action_dict'])
+            timestep.pop('action_dict')
             reward.append(timestep['reward'])
             timestep.pop('reward')
             is_last.append(timestep['is_last'])
@@ -287,6 +259,7 @@ class OpenXDataset(Dataset):
             'text_observation': text_observation,
             'image_observation': image_observation,
             'action': concatenated_action_float,
+            'action_dict': action_dict,
             'reward': reward,
             'is_last': is_last,
             'text_answer': text_answer

--- a/src/eval/profiling/openpi/scripts/openx_inference.py
+++ b/src/eval/profiling/openpi/scripts/openx_inference.py
@@ -43,12 +43,6 @@ class DatasetConfig:
     RESULTS_FILENAME = 'pi0_base_openx_results.json'
     STATS_FILENAME_TEMPLATE = '{dataset_name}_stats.json'
 
-class ActionComponents:
-    WORLD_VECTOR_DIM = 3
-    ROTATION_DELTA_DIM = 3
-    OPEN_GRIPPER_DIM = 1
-    TERMINATE_EPISODE_DIM = 1
-
 # Setup logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
@@ -172,6 +166,15 @@ def _create_action_tensor_from_dict(action_dict: Dict[str, np.ndarray], dataset_
         else:
             logger.warning(f"Bridge OXE dataset missing required keys: world_vector, rotation_delta, open_gripper")
             return None
+    
+    # Concatenate all action components if we have any
+    if action_components:
+        action_tensor = np.concatenate(action_components)
+        logger.info(f"Created action tensor with shape {action_tensor.shape} for dataset {dataset_name}")
+        return action_tensor
+    else:
+        logger.warning(f"No valid action components found for dataset {dataset_name}")
+        return None
 
 
 def _calculate_batch_metrics(pred_actions, gt_actions, action_stats=None):


### PR DESCRIPTION
Some datasets in OpenX have action dictionaries, whose elements need to be concatenated a certain way to create the GT action tensors. We are utilizing the magma specifications to create these concatenated action tensors. Based on this fix, some changes were required for the Pi0 x OpenX inference script. This PR implements all of the above.